### PR TITLE
feat: show hourly weather on court slots

### DIFF
--- a/src/app/api/courts/route.ts
+++ b/src/app/api/courts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchAllCourts } from "@/lib/recus";
+import { enrichCourtsWithWeather } from "@/lib/weather";
 import {
   AVAILABILITY_CACHE_SECONDS,
   SPORT_ID_TENNIS,
@@ -59,8 +60,10 @@ export async function GET(request: NextRequest) {
       })
       .filter((loc) => loc.courts.length > 0);
 
+    const courtsWithWeather = await enrichCourtsWithWeather(courts);
+
     return NextResponse.json(
-      { courts, sport, city: cityId, fetchedAt: new Date().toISOString() },
+      { courts: courtsWithWeather, sport, city: cityId, fetchedAt: new Date().toISOString() },
       {
         headers: {
           "Cache-Control": `s-maxage=${AVAILABILITY_CACHE_SECONDS}, stale-while-revalidate=300`,

--- a/src/components/SlotGrid.tsx
+++ b/src/components/SlotGrid.tsx
@@ -94,9 +94,21 @@ export function SlotGrid({ courts }: SlotGridProps) {
                     href={court.bookingUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="px-2 py-1 text-xs bg-green-50 text-green-700 rounded border border-green-200 hover:bg-green-100 transition-colors"
+                    className="px-2 py-1 text-xs bg-green-50 text-green-700 rounded border border-green-200 hover:bg-green-100 transition-colors min-w-[72px]"
+                    title={slot.weather ? `${slot.weather.label}${slot.weather.temperatureC !== null ? `, ${slot.weather.temperatureC}°C` : ""}${slot.weather.precipitationProbability !== null ? `, ${slot.weather.precipitationProbability}% rain` : ""}` : undefined}
                   >
-                    {slot.time}
+                    <div className="font-medium">{slot.time}</div>
+                    {slot.weather && (
+                      <div className="mt-0.5 flex items-center gap-1 text-[10px] text-green-800/80">
+                        <span>{slot.weather.emoji}</span>
+                        {slot.weather.temperatureC !== null && (
+                          <span>{slot.weather.temperatureC}°</span>
+                        )}
+                        {slot.weather.precipitationProbability !== null && slot.weather.precipitationProbability >= 20 && (
+                          <span>{slot.weather.precipitationProbability}%</span>
+                        )}
+                      </div>
+                    )}
                   </a>
                 ))}
               </div>

--- a/src/components/SlotGrid.tsx
+++ b/src/components/SlotGrid.tsx
@@ -95,7 +95,7 @@ export function SlotGrid({ courts }: SlotGridProps) {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="px-2 py-1 text-xs bg-green-50 text-green-700 rounded border border-green-200 hover:bg-green-100 transition-colors min-w-[72px]"
-                    title={slot.weather ? `${slot.weather.label}${slot.weather.temperatureC !== null ? `, ${slot.weather.temperatureC}°C` : ""}${slot.weather.precipitationProbability !== null ? `, ${slot.weather.precipitationProbability}% rain` : ""}` : undefined}
+                    title={slot.weather ? formatWeatherTooltip(slot.weather) : undefined}
                   >
                     <div className="font-medium">{slot.time}</div>
                     {slot.weather && (
@@ -105,7 +105,10 @@ export function SlotGrid({ courts }: SlotGridProps) {
                           <span>{slot.weather.temperatureC}°</span>
                         )}
                         {slot.weather.precipitationProbability !== null && slot.weather.precipitationProbability >= 20 && (
-                          <span>{slot.weather.precipitationProbability}%</span>
+                          <span className="text-blue-700/80">☔ {slot.weather.precipitationProbability}%</span>
+                        )}
+                        {slot.weather.windSpeedKph !== null && slot.weather.windSpeedKph >= 18 && (
+                          <span className="text-gray-600/80">💨 {slot.weather.windSpeedKph}</span>
                         )}
                       </div>
                     )}
@@ -134,4 +137,20 @@ function formatDateShort(dateStr: string): string {
     day: "numeric",
     timeZone: "America/Los_Angeles",
   });
+}
+
+function formatWeatherTooltip(weather: NonNullable<TimeSlot["weather"]>): string {
+  const parts = [weather.label];
+
+  if (weather.temperatureC !== null) {
+    parts.push(`${weather.temperatureC}°C`);
+  }
+  if (weather.precipitationProbability !== null) {
+    parts.push(`${weather.precipitationProbability}% rain`);
+  }
+  if (weather.windSpeedKph !== null) {
+    parts.push(`${weather.windSpeedKph} km/h wind`);
+  }
+
+  return parts.join(" • ");
 }

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -1,0 +1,163 @@
+import type { CourtLocation, SlotWeather } from "@/types";
+
+const OPEN_METEO_BASE = "https://api.open-meteo.com/v1/forecast";
+const WEATHER_BATCH_SIZE = 8;
+
+interface OpenMeteoResponse {
+  hourly?: {
+    time?: string[];
+    temperature_2m?: number[];
+    precipitation_probability?: number[];
+    weather_code?: number[];
+  };
+}
+
+export async function enrichCourtsWithWeather(
+  locations: CourtLocation[]
+): Promise<CourtLocation[]> {
+  const weatherByLocation = new Map<string, Map<string, SlotWeather>>();
+
+  for (let i = 0; i < locations.length; i += WEATHER_BATCH_SIZE) {
+    const batch = locations.slice(i, i + WEATHER_BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (location) => {
+        const weather = await fetchLocationWeather(location.lat, location.lng);
+        return { locationId: location.id, weather };
+      })
+    );
+
+    for (const result of results) {
+      weatherByLocation.set(result.locationId, result.weather);
+    }
+  }
+
+  return locations.map((location) => {
+    const weather = weatherByLocation.get(location.id) ?? new Map<string, SlotWeather>();
+
+    return {
+      ...location,
+      courts: location.courts.map((court) => ({
+        ...court,
+        availableSlots: court.availableSlots.map((slot) => ({
+          ...slot,
+          weather: weather.get(normalizeSlotKey(slot.date, slot.time)) ?? null,
+        })),
+      })),
+    };
+  });
+}
+
+async function fetchLocationWeather(
+  lat: number,
+  lng: number
+): Promise<Map<string, SlotWeather>> {
+  try {
+    const url = new URL(OPEN_METEO_BASE);
+    url.searchParams.set("latitude", String(lat));
+    url.searchParams.set("longitude", String(lng));
+    url.searchParams.set("hourly", "temperature_2m,precipitation_probability,weather_code");
+    url.searchParams.set("forecast_days", "7");
+    url.searchParams.set("timezone", "America/Los_Angeles");
+
+    const res = await fetch(url.toString(), {
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return new Map();
+
+    const data: OpenMeteoResponse = await res.json();
+    const times = data.hourly?.time ?? [];
+    const temps = data.hourly?.temperature_2m ?? [];
+    const precip = data.hourly?.precipitation_probability ?? [];
+    const codes = data.hourly?.weather_code ?? [];
+
+    const out = new Map<string, SlotWeather>();
+    for (let i = 0; i < times.length; i++) {
+      const time = times[i]; // 2026-04-11T08:00
+      const [date, hhmm] = time.split("T");
+      const key = normalizeSlotKey(date, hhmm.slice(0, 5));
+      out.set(key, formatWeather(temps[i], precip[i], codes[i]));
+    }
+
+    return out;
+  } catch {
+    return new Map();
+  }
+}
+
+function normalizeSlotKey(date: string, time: string): string {
+  const [hourRaw, minuteRaw] = time.split(":");
+  const hour = Number.parseInt(hourRaw, 10);
+  const minute = Number.parseInt(minuteRaw, 10);
+  const roundedHour = minute >= 30 ? hour + 1 : hour;
+
+  const normalizedDate = new Date(`${date}T12:00:00-07:00`);
+  if (roundedHour >= 24) {
+    normalizedDate.setDate(normalizedDate.getDate() + 1);
+  }
+
+  const nextDate = normalizedDate.toLocaleDateString("en-CA", {
+    timeZone: "America/Los_Angeles",
+  });
+  const nextHour = roundedHour % 24;
+  return `${nextDate} ${String(nextHour).padStart(2, "0")}:00`;
+}
+
+function formatWeather(
+  temperatureC?: number,
+  precipitationProbability?: number,
+  weatherCode?: number
+): SlotWeather {
+  const { label, emoji } = describeWeatherCode(weatherCode ?? null);
+  return {
+    temperatureC: Number.isFinite(temperatureC) ? Math.round(temperatureC as number) : null,
+    precipitationProbability: Number.isFinite(precipitationProbability)
+      ? Math.round(precipitationProbability as number)
+      : null,
+    weatherCode: Number.isFinite(weatherCode) ? Math.round(weatherCode as number) : null,
+    label,
+    emoji,
+  };
+}
+
+function describeWeatherCode(code: number | null): { label: string; emoji: string } {
+  switch (code) {
+    case 0:
+      return { label: "Clear", emoji: "☀️" };
+    case 1:
+    case 2:
+      return { label: "Partly cloudy", emoji: "⛅" };
+    case 3:
+      return { label: "Cloudy", emoji: "☁️" };
+    case 45:
+    case 48:
+      return { label: "Fog", emoji: "🌫️" };
+    case 51:
+    case 53:
+    case 55:
+    case 56:
+    case 57:
+      return { label: "Drizzle", emoji: "🌦️" };
+    case 61:
+    case 63:
+    case 65:
+    case 66:
+    case 67:
+    case 80:
+    case 81:
+    case 82:
+      return { label: "Rain", emoji: "🌧️" };
+    case 71:
+    case 73:
+    case 75:
+    case 77:
+    case 85:
+    case 86:
+      return { label: "Snow", emoji: "🌨️" };
+    case 95:
+    case 96:
+    case 99:
+      return { label: "Storm", emoji: "⛈️" };
+    default:
+      return { label: "Forecast", emoji: "🌤️" };
+  }
+}

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -9,6 +9,7 @@ interface OpenMeteoResponse {
     temperature_2m?: number[];
     precipitation_probability?: number[];
     weather_code?: number[];
+    wind_speed_10m?: number[];
   };
 }
 
@@ -55,7 +56,10 @@ async function fetchLocationWeather(
     const url = new URL(OPEN_METEO_BASE);
     url.searchParams.set("latitude", String(lat));
     url.searchParams.set("longitude", String(lng));
-    url.searchParams.set("hourly", "temperature_2m,precipitation_probability,weather_code");
+    url.searchParams.set(
+      "hourly",
+      "temperature_2m,precipitation_probability,weather_code,wind_speed_10m"
+    );
     url.searchParams.set("forecast_days", "7");
     url.searchParams.set("timezone", "America/Los_Angeles");
 
@@ -69,13 +73,14 @@ async function fetchLocationWeather(
     const temps = data.hourly?.temperature_2m ?? [];
     const precip = data.hourly?.precipitation_probability ?? [];
     const codes = data.hourly?.weather_code ?? [];
+    const wind = data.hourly?.wind_speed_10m ?? [];
 
     const out = new Map<string, SlotWeather>();
     for (let i = 0; i < times.length; i++) {
       const time = times[i]; // 2026-04-11T08:00
       const [date, hhmm] = time.split("T");
       const key = normalizeSlotKey(date, hhmm.slice(0, 5));
-      out.set(key, formatWeather(temps[i], precip[i], codes[i]));
+      out.set(key, formatWeather(temps[i], precip[i], codes[i], wind[i]));
     }
 
     return out;
@@ -105,7 +110,8 @@ function normalizeSlotKey(date: string, time: string): string {
 function formatWeather(
   temperatureC?: number,
   precipitationProbability?: number,
-  weatherCode?: number
+  weatherCode?: number,
+  windSpeedKph?: number
 ): SlotWeather {
   const { label, emoji } = describeWeatherCode(weatherCode ?? null);
   return {
@@ -113,6 +119,7 @@ function formatWeather(
     precipitationProbability: Number.isFinite(precipitationProbability)
       ? Math.round(precipitationProbability as number)
       : null,
+    windSpeedKph: Number.isFinite(windSpeedKph) ? Math.round(windSpeedKph as number) : null,
     weatherCode: Number.isFinite(weatherCode) ? Math.round(weatherCode as number) : null,
     label,
     emoji,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,6 +86,15 @@ export interface TimeSlot {
   datetime: string; // ISO-ish: "2026-03-30 07:30:00"
   date: string; // "2026-03-30"
   time: string; // "07:30"
+  weather?: SlotWeather | null;
+}
+
+export interface SlotWeather {
+  temperatureC: number | null;
+  precipitationProbability: number | null;
+  weatherCode: number | null;
+  label: string;
+  emoji: string;
 }
 
 export interface TravelTime {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,6 +92,7 @@ export interface TimeSlot {
 export interface SlotWeather {
   temperatureC: number | null;
   precipitationProbability: number | null;
+  windSpeedKph: number | null;
   weatherCode: number | null;
   label: string;
   emoji: string;


### PR DESCRIPTION
## Summary
- fetch free hourly forecast data from Open-Meteo for each court location
- enrich available slots server-side with weather summaries
- show compact weather info directly inside each bookable time slot

## Why
Marvin wanted weather forecasts visible for each actual booking time slot, using a free data source.

## Notes
- uses Open-Meteo (no API key)
- rounds each slot to the nearest forecast hour in PT
- build passes with `npm run build`
