### PR TITLE
Add location retry button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -125,7 +125,9 @@ export default function Home() {
         sport={sport}
         city={city}
         courtCount={courts.length}
+        userLocationStatus={userLocation.status}
         onRefresh={refresh}
+        onRequestLocation={userLocation.requestLocation}
         onToggleView={() => setViewMode((m) => (m === "map" ? "list" : "map"))}
         onShowSearch={() => setShowSearch(true)}
         onShowLogin={() => setShowLogin(true)}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -16,7 +16,9 @@ interface TopBarProps {
   sport: Sport;
   city: CityId;
   courtCount: number;
+  userLocationStatus: "idle" | "requesting" | "resolved" | "fallback" | "unsupported";
   onRefresh: () => void;
+  onRequestLocation: () => void;
   onToggleView: () => void;
   onShowSearch: () => void;
   onShowLogin: () => void;
@@ -37,7 +39,9 @@ export function TopBar({
   sport,
   city,
   courtCount,
+  userLocationStatus,
   onRefresh,
+  onRequestLocation,
   onToggleView,
   onShowSearch,
   onShowLogin,
@@ -51,6 +55,14 @@ export function TopBar({
   const cityConfig = CITIES[city];
   const sportEmoji = sport === "tennis" ? "🎾" : "🏓";
   const sportLabel = sport === "tennis" ? "Tennis" : "Pickleball";
+  const locationLabel =
+    userLocationStatus === "requesting"
+      ? "Locating…"
+      : userLocationStatus === "resolved"
+      ? "My location"
+      : userLocationStatus === "unsupported"
+      ? "Location unavailable"
+      : "Use my location";
 
   return (
     <div className="absolute top-0 left-0 right-0 z-10 bg-white/90 backdrop-blur-sm border-b shadow-sm">
@@ -106,6 +118,22 @@ export function TopBar({
               ↻
             </button>
           )}
+
+          <button
+            onClick={onRequestLocation}
+            disabled={userLocationStatus === "requesting"}
+            aria-label={locationLabel}
+            title={locationLabel}
+            className={`px-2 py-1 text-xs rounded transition-colors disabled:opacity-50 ${
+              userLocationStatus === "resolved"
+                ? "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                : userLocationStatus === "unsupported"
+                ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                : "bg-gray-100 hover:bg-gray-200"
+            }`}
+          >
+            {userLocationStatus === "requesting" ? "📡" : "📍"}
+          </button>
 
           {/* Map/List toggle */}
           <button

--- a/src/hooks/useUserLocation.ts
+++ b/src/hooks/useUserLocation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { CITIES, DEFAULT_CITY } from "@/lib/constants";
 import type { CityId } from "@/lib/constants";
 
@@ -10,11 +10,18 @@ export interface UserLocation {
   isDefault: boolean; // true = fallback to city center
 }
 
+interface UseUserLocationResult extends UserLocation {
+  status: "idle" | "requesting" | "resolved" | "fallback" | "unsupported";
+  requestLocation: () => void;
+}
+
 /**
- * One-shot browser geolocation.
- * Falls back silently to city center on denial or error.
+ * Browser geolocation with explicit retry support.
+ * Falls back to city center on denial or error.
  */
-export function useUserLocation(cityId: CityId = DEFAULT_CITY): UserLocation {
+export function useUserLocation(
+  cityId: CityId = DEFAULT_CITY
+): UseUserLocationResult {
   const city = CITIES[cityId] ?? CITIES[DEFAULT_CITY];
   const [location, setLocation] = useState<UserLocation>({
     lat: city.lat,
@@ -22,17 +29,30 @@ export function useUserLocation(cityId: CityId = DEFAULT_CITY): UserLocation {
     isDefault: true,
   });
   const [geoResolved, setGeoResolved] = useState(false);
+  const [requestVersion, setRequestVersion] = useState(0);
+  const [status, setStatus] = useState<UseUserLocationResult["status"]>("idle");
 
   // Update fallback when city changes (only if geolocation hasn't resolved)
   useEffect(() => {
     if (!geoResolved) {
       setLocation({ lat: city.lat, lng: city.lng, isDefault: true });
+      setStatus((current) =>
+        current === "unsupported" ? current : geoResolved ? current : "fallback"
+      );
     }
   }, [cityId, city.lat, city.lng, geoResolved]);
 
-  useEffect(() => {
-    if (!navigator.geolocation) return;
+  const requestLocation = useCallback(() => {
+    setRequestVersion((v) => v + 1);
+  }, []);
 
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setStatus("unsupported");
+      return;
+    }
+
+    setStatus("requesting");
     navigator.geolocation.getCurrentPosition(
       (pos) => {
         setLocation({
@@ -41,14 +61,24 @@ export function useUserLocation(cityId: CityId = DEFAULT_CITY): UserLocation {
           isDefault: false,
         });
         setGeoResolved(true);
+        setStatus("resolved");
       },
       () => {
-        // Denied or error — keep default, no-op
+        setGeoResolved(false);
+        setLocation({ lat: city.lat, lng: city.lng, isDefault: true });
+        setStatus("fallback");
       },
       { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 }
     );
-  }, []);
+  }, [city.lat, city.lng, requestVersion]);
 
   // Memoize so consumers get a stable reference when lat/lng haven't changed
-  return useMemo(() => location, [location.lat, location.lng, location.isDefault]);
+  return useMemo(
+    () => ({
+      ...location,
+      status,
+      requestLocation,
+    }),
+    [location.lat, location.lng, location.isDefault, requestLocation, status]
+  );
 }


### PR DESCRIPTION
## Summary\n- add a simple top-bar location button so mobile users can retrigger geolocation\n- expose geolocation status and retry from the user location hook\n- keep the UX lightweight with a small location icon that reflects loading/resolved state\n\n## Testing\n- npm run build\n