### PR TITLE
Fix mobile location retry flow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,6 +66,7 @@ export default function Home() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<AvailabilityFilter>({
     date: null,
+    weekendOnly: false,
     timeFrom: null,
     timeTo: null,
   });
@@ -127,7 +128,7 @@ export default function Home() {
         courtCount={courts.length}
         userLocationStatus={userLocation.status}
         onRefresh={refresh}
-        onRequestLocation={userLocation.requestLocation}
+        onRequestLocation={() => userLocation.requestLocation({ forceFresh: true })}
         onToggleView={() => setViewMode((m) => (m === "map" ? "list" : "map"))}
         onShowSearch={() => setShowSearch(true)}
         onShowLogin={() => setShowLogin(true)}
@@ -239,6 +240,8 @@ export default function Home() {
           onSportChange={handleSportChange}
           onCityChange={handleCityChange}
           onFilterChange={setFilter}
+          onRequestLocation={() => userLocation.requestLocation({ forceFresh: true })}
+          userLocationStatus={userLocation.status}
           onClose={() => setShowSearch(false)}
         />
       )}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import type { CourtLocation, TravelTime, AvailabilityFilter } from "@/types";
 import type { Sport, CityId, CityConfig } from "@/lib/constants";
 import { CITIES } from "@/lib/constants";
+import type { UserLocationStatus } from "@/hooks/useUserLocation";
 
 interface CommandPaletteProps {
   courts: CourtLocation[];
@@ -13,7 +14,7 @@ interface CommandPaletteProps {
   city: CityId;
   filter: AvailabilityFilter;
   availableDates: string[];
-  userLocationStatus: "idle" | "requesting" | "resolved" | "fallback" | "denied" | "unsupported";
+  userLocationStatus: UserLocationStatus;
   onSelectCourt: (id: string) => void;
   onSportChange: (sport: Sport) => void;
   onCityChange: (city: CityId) => void;
@@ -465,7 +466,7 @@ function MobileContent({
   city: CityId;
   filter: AvailabilityFilter;
   availableDates: string[];
-  userLocationStatus: "idle" | "requesting" | "resolved" | "fallback" | "denied" | "unsupported";
+  userLocationStatus: UserLocationStatus;
   onRequestLocation: () => void;
   onSelectCourt: (id: string) => void;
   onSportChange: (sport: Sport) => void;

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -13,10 +13,12 @@ interface CommandPaletteProps {
   city: CityId;
   filter: AvailabilityFilter;
   availableDates: string[];
+  userLocationStatus: "idle" | "requesting" | "resolved" | "fallback" | "denied" | "unsupported";
   onSelectCourt: (id: string) => void;
   onSportChange: (sport: Sport) => void;
   onCityChange: (city: CityId) => void;
   onFilterChange: (filter: AvailabilityFilter) => void;
+  onRequestLocation: () => void;
   onClose: () => void;
 }
 
@@ -36,10 +38,12 @@ export function CommandPalette({
   city,
   filter,
   availableDates,
+  userLocationStatus,
   onSelectCourt,
   onSportChange,
   onCityChange,
   onFilterChange,
+  onRequestLocation,
   onClose,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
@@ -158,8 +162,15 @@ export function CommandPalette({
         type: "filter",
         id: "filter-any",
         label: "Any day",
-        active: !filter.date,
-        filterValue: { ...filter, date: null },
+        active: !filter.date && !filter.weekendOnly,
+        filterValue: { ...filter, date: null, weekendOnly: false },
+      });
+      result.push({
+        type: "filter",
+        id: "filter-weekend",
+        label: "🌴 Weekend",
+        active: Boolean(filter.weekendOnly),
+        filterValue: { ...filter, date: null, weekendOnly: true },
       });
       for (const d of availableDates) {
         result.push({
@@ -317,10 +328,16 @@ export function CommandPalette({
           <div className="flex items-center gap-1.5 px-4 py-2 border-b bg-gray-50/50 flex-wrap flex-shrink-0">
             <Pill>{CITIES[city]?.shortLabel ?? city}</Pill>
             <Pill>{sport === "tennis" ? "🎾 Tennis" : "🏓 Pickleball"}</Pill>
-            {filter.date && (
-              <Pill onRemove={() => onFilterChange({ ...filter, date: null })}>
-                {formatDateLabel(filter.date)}
+            {filter.weekendOnly ? (
+              <Pill onRemove={() => onFilterChange({ ...filter, weekendOnly: false })}>
+                🌴 Weekend
               </Pill>
+            ) : (
+              filter.date && (
+                <Pill onRemove={() => onFilterChange({ ...filter, date: null })}>
+                  {formatDateLabel(filter.date)}
+                </Pill>
+              )
             )}
             {filter.timeFrom && (
               <Pill
@@ -363,6 +380,8 @@ export function CommandPalette({
             city={city}
             filter={filter}
             availableDates={availableDates}
+            userLocationStatus={userLocationStatus}
+            onRequestLocation={onRequestLocation}
             onSelectCourt={(id) => {
               onSelectCourt(id);
               onClose();
@@ -393,8 +412,8 @@ export function CommandPalette({
           <MobileTabButton
             active={mobileTab === "city"}
             onClick={() => setMobileTab("city")}
-            icon="📍"
-            label={CITIES[city]?.shortLabel ?? "City"}
+            icon={userLocationStatus === "requesting" ? "📡" : "📍"}
+            label={userLocationStatus === "resolved" ? "Near me" : CITIES[city]?.shortLabel ?? "City"}
           />
           <MobileTabButton
             active={mobileTab === "sport"}
@@ -431,6 +450,8 @@ function MobileContent({
   city,
   filter,
   availableDates,
+  userLocationStatus,
+  onRequestLocation,
   onSelectCourt,
   onSportChange,
   onCityChange,
@@ -444,6 +465,8 @@ function MobileContent({
   city: CityId;
   filter: AvailabilityFilter;
   availableDates: string[];
+  userLocationStatus: "idle" | "requesting" | "resolved" | "fallback" | "denied" | "unsupported";
+  onRequestLocation: () => void;
   onSelectCourt: (id: string) => void;
   onSportChange: (sport: Sport) => void;
   onCityChange: (city: CityId) => void;
@@ -476,11 +499,32 @@ function MobileContent({
     const cityEntries = Object.entries(CITIES) as [CityId, CityConfig][];
     return (
       <div className="divide-y">
+        <MobileOptionRow
+          label={
+            userLocationStatus === "requesting"
+              ? "Finding my location…"
+              : userLocationStatus === "resolved"
+              ? "Refresh my location"
+              : "Use my location"
+          }
+          active={userLocationStatus === "resolved"}
+          disabled={userLocationStatus === "unsupported"}
+          helper={
+            userLocationStatus === "unsupported"
+              ? "Location isn’t available on this device/browser"
+              : userLocationStatus === "denied"
+              ? "Location permission is blocked in the browser"
+              : userLocationStatus === "fallback"
+              ? "Currently using the city center"
+              : undefined
+          }
+          onSelect={onRequestLocation}
+        />
         {cityEntries.map(([id, c]) => (
           <MobileOptionRow
             key={id}
             label={c.label}
-            active={id === city}
+            active={id === city && userLocationStatus !== "resolved"}
             onSelect={() => onCityChange(id)}
           />
         ))}
@@ -510,15 +554,20 @@ function MobileContent({
       <div className="divide-y">
         <MobileOptionRow
           label="Any day"
-          active={!filter.date}
-          onSelect={() => onFilterChange({ ...filter, date: null })}
+          active={!filter.date && !filter.weekendOnly}
+          onSelect={() => onFilterChange({ ...filter, date: null, weekendOnly: false })}
+        />
+        <MobileOptionRow
+          label="🌴 Weekend"
+          active={Boolean(filter.weekendOnly)}
+          onSelect={() => onFilterChange({ ...filter, date: null, weekendOnly: true })}
         />
         {availableDates.map((d) => (
           <MobileOptionRow
             key={d}
             label={formatDateLabel(d)}
-            active={filter.date === d}
-            onSelect={() => onFilterChange({ ...filter, date: d })}
+            active={!filter.weekendOnly && filter.date === d}
+            onSelect={() => onFilterChange({ ...filter, date: d, weekendOnly: false })}
           />
         ))}
       </div>
@@ -674,19 +723,27 @@ function MobileOptionRow({
   label,
   active,
   onSelect,
+  helper,
+  disabled = false,
 }: {
   label: string;
   active: boolean;
   onSelect: () => void;
+  helper?: string;
+  disabled?: boolean;
 }) {
   return (
     <button
       onClick={onSelect}
-      className="w-full text-left px-4 py-4 flex items-center justify-between active:bg-gray-100 min-h-[56px]"
+      disabled={disabled}
+      className="w-full text-left px-4 py-4 flex items-center justify-between active:bg-gray-100 min-h-[56px] disabled:opacity-50"
     >
-      <span className={`text-base ${active ? "font-semibold text-blue-600" : "text-gray-800"}`}>
-        {label}
-      </span>
+      <div className="min-w-0">
+        <span className={`block text-base ${active ? "font-semibold text-blue-600" : "text-gray-800"}`}>
+          {label}
+        </span>
+        {helper && <span className="block text-xs text-gray-500 mt-0.5">{helper}</span>}
+      </div>
       {active && <span className="text-blue-600 text-lg">✓</span>}
     </button>
   );

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -5,6 +5,7 @@ import { TimeSince } from "./TimeSince";
 import type { Friend } from "@/types";
 import type { Sport, CityId } from "@/lib/constants";
 import { CITIES } from "@/lib/constants";
+import type { UserLocationStatus } from "@/hooks/useUserLocation";
 
 interface TopBarProps {
   loading: boolean;
@@ -16,7 +17,7 @@ interface TopBarProps {
   sport: Sport;
   city: CityId;
   courtCount: number;
-  userLocationStatus: "idle" | "requesting" | "resolved" | "fallback" | "denied" | "unsupported";
+  userLocationStatus: UserLocationStatus;
   onRefresh: () => void;
   onRequestLocation: () => void;
   onToggleView: () => void;

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -16,7 +16,7 @@ interface TopBarProps {
   sport: Sport;
   city: CityId;
   courtCount: number;
-  userLocationStatus: "idle" | "requesting" | "resolved" | "fallback" | "unsupported";
+  userLocationStatus: "idle" | "requesting" | "resolved" | "fallback" | "denied" | "unsupported";
   onRefresh: () => void;
   onRequestLocation: () => void;
   onToggleView: () => void;
@@ -60,6 +60,8 @@ export function TopBar({
       ? "Locating…"
       : userLocationStatus === "resolved"
       ? "My location"
+      : userLocationStatus === "denied"
+      ? "Location blocked"
       : userLocationStatus === "unsupported"
       ? "Location unavailable"
       : "Use my location";
@@ -127,6 +129,8 @@ export function TopBar({
             className={`px-2 py-1 text-xs rounded transition-colors disabled:opacity-50 ${
               userLocationStatus === "resolved"
                 ? "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                : userLocationStatus === "denied"
+                ? "bg-amber-50 text-amber-700 hover:bg-amber-100"
                 : userLocationStatus === "unsupported"
                 ? "bg-gray-100 text-gray-400 cursor-not-allowed"
                 : "bg-gray-100 hover:bg-gray-200"

--- a/src/hooks/useUserLocation.ts
+++ b/src/hooks/useUserLocation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { CITIES, DEFAULT_CITY } from "@/lib/constants";
 import type { CityId } from "@/lib/constants";
 
@@ -10,14 +10,16 @@ export interface UserLocation {
   isDefault: boolean; // true = fallback to city center
 }
 
+export type UserLocationStatus =
+  | "idle"
+  | "requesting"
+  | "resolved"
+  | "fallback"
+  | "denied"
+  | "unsupported";
+
 interface UseUserLocationResult extends UserLocation {
-  status:
-    | "idle"
-    | "requesting"
-    | "resolved"
-    | "fallback"
-    | "denied"
-    | "unsupported";
+  status: UserLocationStatus;
   requestLocation: (options?: { forceFresh?: boolean }) => void;
 }
 
@@ -36,9 +38,9 @@ export function useUserLocation(
   });
   const [geoResolved, setGeoResolved] = useState(false);
   const [requestVersion, setRequestVersion] = useState(0);
-  const [forceFresh, setForceFresh] = useState(false);
   const [shouldRequest, setShouldRequest] = useState(false);
-  const [status, setStatus] = useState<UseUserLocationResult["status"]>("idle");
+  const [status, setStatus] = useState<UserLocationStatus>("idle");
+  const forceFreshRef = useRef(false);
 
   // Update fallback when city changes (only if geolocation hasn't resolved)
   useEffect(() => {
@@ -52,7 +54,7 @@ export function useUserLocation(
   }, [cityId, city.lat, city.lng, geoResolved]);
 
   const requestLocation = useCallback((options?: { forceFresh?: boolean }) => {
-    setForceFresh(Boolean(options?.forceFresh));
+    forceFreshRef.current = Boolean(options?.forceFresh);
     setShouldRequest(true);
     setRequestVersion((v) => v + 1);
   }, []);
@@ -106,6 +108,7 @@ export function useUserLocation(
       return;
     }
 
+    const forceFresh = forceFreshRef.current;
     setStatus("requesting");
     navigator.geolocation.getCurrentPosition(
       (pos) => {
@@ -117,12 +120,14 @@ export function useUserLocation(
         setGeoResolved(true);
         setStatus("resolved");
         setShouldRequest(false);
+        forceFreshRef.current = false;
       },
       (error) => {
         setGeoResolved(false);
         setLocation({ lat: city.lat, lng: city.lng, isDefault: true });
         setStatus(error.code === error.PERMISSION_DENIED ? "denied" : "fallback");
         setShouldRequest(false);
+        forceFreshRef.current = false;
       },
       {
         enableHighAccuracy: forceFresh,
@@ -130,7 +135,7 @@ export function useUserLocation(
         maximumAge: forceFresh ? 0 : 300000,
       }
     );
-  }, [city.lat, city.lng, forceFresh, requestVersion, shouldRequest]);
+  }, [city.lat, city.lng, requestVersion, shouldRequest]);
 
   // Memoize so consumers get a stable reference when lat/lng haven't changed
   return useMemo(

--- a/src/hooks/useUserLocation.ts
+++ b/src/hooks/useUserLocation.ts
@@ -11,8 +11,14 @@ export interface UserLocation {
 }
 
 interface UseUserLocationResult extends UserLocation {
-  status: "idle" | "requesting" | "resolved" | "fallback" | "unsupported";
-  requestLocation: () => void;
+  status:
+    | "idle"
+    | "requesting"
+    | "resolved"
+    | "fallback"
+    | "denied"
+    | "unsupported";
+  requestLocation: (options?: { forceFresh?: boolean }) => void;
 }
 
 /**
@@ -30,23 +36,71 @@ export function useUserLocation(
   });
   const [geoResolved, setGeoResolved] = useState(false);
   const [requestVersion, setRequestVersion] = useState(0);
+  const [forceFresh, setForceFresh] = useState(false);
+  const [shouldRequest, setShouldRequest] = useState(false);
   const [status, setStatus] = useState<UseUserLocationResult["status"]>("idle");
 
   // Update fallback when city changes (only if geolocation hasn't resolved)
   useEffect(() => {
     if (!geoResolved) {
       setLocation({ lat: city.lat, lng: city.lng, isDefault: true });
-      setStatus((current) =>
-        current === "unsupported" ? current : geoResolved ? current : "fallback"
-      );
+      setStatus((current) => {
+        if (current === "unsupported" || current === "denied") return current;
+        return geoResolved ? current : "fallback";
+      });
     }
   }, [cityId, city.lat, city.lng, geoResolved]);
 
-  const requestLocation = useCallback(() => {
+  const requestLocation = useCallback((options?: { forceFresh?: boolean }) => {
+    setForceFresh(Boolean(options?.forceFresh));
+    setShouldRequest(true);
     setRequestVersion((v) => v + 1);
   }, []);
 
   useEffect(() => {
+    if (!navigator.geolocation) {
+      setStatus("unsupported");
+      return;
+    }
+
+    const permissions = navigator.permissions as
+      | {
+          query?: (descriptor: { name: PermissionName }) => Promise<PermissionStatus>;
+        }
+      | undefined;
+
+    if (!permissions?.query) {
+      setStatus((current) => (current === "idle" ? "fallback" : current));
+      return;
+    }
+
+    let cancelled = false;
+    permissions
+      .query({ name: "geolocation" as PermissionName })
+      .then((result) => {
+        if (cancelled) return;
+        if (result.state === "granted") {
+          setShouldRequest(true);
+          setRequestVersion((v) => v + 1);
+        } else if (result.state === "denied") {
+          setStatus("denied");
+        } else {
+          setStatus((current) => (current === "idle" ? "fallback" : current));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStatus((current) => (current === "idle" ? "fallback" : current));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!shouldRequest) return;
     if (!navigator.geolocation) {
       setStatus("unsupported");
       return;
@@ -62,15 +116,21 @@ export function useUserLocation(
         });
         setGeoResolved(true);
         setStatus("resolved");
+        setShouldRequest(false);
       },
-      () => {
+      (error) => {
         setGeoResolved(false);
         setLocation({ lat: city.lat, lng: city.lng, isDefault: true });
-        setStatus("fallback");
+        setStatus(error.code === error.PERMISSION_DENIED ? "denied" : "fallback");
+        setShouldRequest(false);
       },
-      { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 }
+      {
+        enableHighAccuracy: forceFresh,
+        timeout: forceFresh ? 15000 : 10000,
+        maximumAge: forceFresh ? 0 : 300000,
+      }
     );
-  }, [city.lat, city.lng, requestVersion]);
+  }, [city.lat, city.lng, forceFresh, requestVersion, shouldRequest]);
 
   // Memoize so consumers get a stable reference when lat/lng haven't changed
   return useMemo(

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -67,7 +67,7 @@ export function getAvailableDates(courts: CourtLocation[]): string[] {
 }
 
 function isWeekendDate(dateStr: string): boolean {
-  const date = new Date(`${dateStr}T12:00:00-07:00`);
-  const day = date.getDay();
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const day = new Date(Date.UTC(y, m - 1, d)).getUTCDay();
   return day === 0 || day === 6;
 }

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -8,13 +8,14 @@ export function applyFilter(
   courts: CourtLocation[],
   filter: AvailabilityFilter
 ): CourtLocation[] {
-  const hasFilter = filter.date || filter.timeFrom || filter.timeTo;
+  const hasFilter = filter.date || filter.weekendOnly || filter.timeFrom || filter.timeTo;
   if (!hasFilter) return courts;
 
   return courts.map((loc) => {
     const filteredCourts = loc.courts.map((court) => {
       const filteredSlots = court.availableSlots.filter((slot) => {
         if (filter.date && slot.date !== filter.date) return false;
+        if (filter.weekendOnly && !isWeekendDate(slot.date)) return false;
         if (filter.timeFrom && slot.time < filter.timeFrom) return false;
         if (filter.timeTo && slot.time > filter.timeTo) return false;
         return true;
@@ -63,4 +64,10 @@ export function getAvailableDates(courts: CourtLocation[]): string[] {
     }
   }
   return Array.from(dates).sort();
+}
+
+function isWeekendDate(dateStr: string): boolean {
+  const date = new Date(`${dateStr}T12:00:00-07:00`);
+  const day = date.getDay();
+  return day === 0 || day === 6;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,6 +109,7 @@ export interface TravelTime {
 
 export interface AvailabilityFilter {
   date: string | null; // "2026-03-30" or null for any day
+  weekendOnly?: boolean;
   timeFrom: string | null; // "09:00" or null
   timeTo: string | null; // "17:00" or null
 }


### PR DESCRIPTION
## What changed
- stop auto-requesting geolocation on first page load unless permission was already granted
- keep the simple pin entry point, but make the mobile City-tab retry flow explicit and clearer
- distinguish blocked location permission from generic fallback so the UI can explain what happened
- carry over the weekend filter that never made it into the merged branch

## Why
PR #2 merged only the first commit and missed the later follow-up. More importantly, I hadn't properly verified the mobile behavior before shipping it. This patch fixes the actual flow from the real merged base.

## Verification
- npm run build
