### PR TITLE
Security: HMAC-signed sessions + login throttle (PR 1/3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,4 +62,5 @@ Required in `.env.local` for dev and as Worker secrets in prod:
 - `NEXT_PUBLIC_MAPBOX_TOKEN` — public Mapbox token for map tiles (shipped to browser).
 - `MAPBOX_SECRET_TOKEN` — server-side Mapbox token for `/api/directions`.
 - `AUTH_PIN` — PIN for browser login.
+- `SESSION_SECRET` — HMAC secret used to sign session cookies. Recommended in prod. If unset, the signing key is derived from `AUTH_PIN` as a fallback (still better than the previous design that embedded the PIN in the cookie, but a dedicated secret means rotating the PIN doesn't invalidate sessions and vice-versa).
 - `API_KEY` — bearer token for `/api/history/external`.

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -6,6 +6,55 @@ import {
   SESSION_DURATION,
 } from "@/lib/auth";
 
+// ── Per-IP login throttle (defense-in-depth against PIN brute force) ──
+//
+// In-memory and per-isolate, just like src/middleware.ts. Coarse, but
+// makes online brute-force impractical for a short PIN. Failed attempts
+// are counted; a successful login resets the counter.
+
+const LOGIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const LOGIN_MAX_FAILURES = 5;
+
+const loginAttempts = new Map<string, { count: number; resetAt: number }>();
+
+function clientIp(request: NextRequest): string {
+  return (
+    request.headers.get("cf-connecting-ip") ??
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown"
+  );
+}
+
+function checkLoginAllowed(ip: string): {
+  allowed: boolean;
+  retryAfter: number;
+} {
+  const now = Date.now();
+  const entry = loginAttempts.get(ip);
+  if (!entry || now > entry.resetAt) return { allowed: true, retryAfter: 0 };
+  if (entry.count >= LOGIN_MAX_FAILURES) {
+    return {
+      allowed: false,
+      retryAfter: Math.ceil((entry.resetAt - now) / 1000),
+    };
+  }
+  return { allowed: true, retryAfter: 0 };
+}
+
+function recordFailure(ip: string): void {
+  const now = Date.now();
+  const entry = loginAttempts.get(ip);
+  if (!entry || now > entry.resetAt) {
+    loginAttempts.set(ip, { count: 1, resetAt: now + LOGIN_WINDOW_MS });
+  } else {
+    entry.count++;
+  }
+}
+
+function resetFailures(ip: string): void {
+  loginAttempts.delete(ip);
+}
+
 /** GET /api/auth — check auth status */
 export async function GET() {
   const authed = await isAuthenticated();
@@ -14,12 +63,38 @@ export async function GET() {
 
 /** POST /api/auth — login with PIN */
 export async function POST(request: NextRequest) {
-  const { pin } = await request.json();
+  const ip = clientIp(request);
+  const gate = checkLoginAllowed(ip);
+  if (!gate.allowed) {
+    return NextResponse.json(
+      { error: "Too many failed attempts. Try again later." },
+      { status: 429, headers: { "Retry-After": String(gate.retryAfter) } }
+    );
+  }
 
-  const sessionValue = verifyPin(pin);
-  if (!sessionValue) {
+  let pin: unknown;
+  try {
+    const body = (await request.json()) as { pin?: unknown };
+    pin = body.pin;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  if (typeof pin !== "string") {
+    recordFailure(ip);
     return NextResponse.json({ error: "Invalid PIN" }, { status: 401 });
   }
+
+  const sessionValue = await verifyPin(pin);
+  if (!sessionValue) {
+    recordFailure(ip);
+    return NextResponse.json({ error: "Invalid PIN" }, { status: 401 });
+  }
+
+  resetFailures(ip);
 
   const response = NextResponse.json({ authenticated: true });
   response.cookies.set(SESSION_COOKIE, sessionValue, {
@@ -36,6 +111,14 @@ export async function POST(request: NextRequest) {
 /** DELETE /api/auth — logout */
 export async function DELETE() {
   const response = NextResponse.json({ authenticated: false });
-  response.cookies.delete(SESSION_COOKIE);
+  // Explicit overwrite with maxAge: 0 is more reliable across UAs than
+  // relying on Set-Cookie deletion semantics alone.
+  response.cookies.set(SESSION_COOKIE, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 0,
+    path: "/",
+  });
   return response;
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,42 +3,123 @@ import { cookies } from "next/headers";
 const SESSION_COOKIE = "sf-tennis-session";
 const SESSION_DURATION = 30 * 24 * 60 * 60; // 30 days in seconds
 
+// ── Constant-time string compare ──
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+// ── HMAC-signed session token ──
+//
+// Session format: `${payload}.${sig}` where
+//   payload = base64url(JSON.stringify({ ts: <unix-seconds> }))
+//   sig     = base64url(HMAC-SHA256(payload, SESSION_SECRET))
+//
+// The PIN never leaves the server. Cookie possession alone is enough to
+// authenticate (which is how cookies work), but cookie exposure no longer
+// discloses the PIN, and the cookie cannot be forged without the secret.
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let str = "";
+  for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlDecodeToString(input: string): string {
+  const pad = input.length % 4 === 0 ? "" : "=".repeat(4 - (input.length % 4));
+  const b64 = input.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  return atob(b64);
+}
+
+async function getSigningKey(): Promise<CryptoKey | null> {
+  // Prefer dedicated SESSION_SECRET. Fall back to deriving from AUTH_PIN so
+  // existing deployments keep working without a new env var (the derivation
+  // is still strictly better than embedding the PIN in the cookie).
+  const explicit = process.env.SESSION_SECRET;
+  const pin = process.env.AUTH_PIN;
+  const secretSource = explicit || (pin ? `pin:${pin}` : null);
+  if (!secretSource) return null;
+
+  const enc = new TextEncoder();
+  // Hash the source so the imported key has uniform 32-byte length
+  // regardless of whether SESSION_SECRET or AUTH_PIN was used.
+  const digest = await crypto.subtle.digest("SHA-256", enc.encode(secretSource));
+  return crypto.subtle.importKey(
+    "raw",
+    digest,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"]
+  );
+}
+
+async function signPayload(payload: string): Promise<string> {
+  const key = await getSigningKey();
+  if (!key) throw new Error("Session secret not configured");
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload)
+  );
+  return base64urlEncode(new Uint8Array(sig));
+}
+
 /**
- * Check if the current request is authenticated (has valid session cookie).
+ * Verify the current session cookie. Returns true iff the cookie has a
+ * valid signature under SESSION_SECRET (or AUTH_PIN-derived fallback) and
+ * has not expired.
  */
 export async function isAuthenticated(): Promise<boolean> {
   const cookieStore = await cookies();
   const session = cookieStore.get(SESSION_COOKIE);
   if (!session?.value) return false;
 
-  // Session value is just a signed timestamp — check it's not expired
+  const dot = session.value.indexOf(".");
+  if (dot <= 0 || dot === session.value.length - 1) return false;
+
+  const payload = session.value.slice(0, dot);
+  const providedSig = session.value.slice(dot + 1);
+
+  let expectedSig: string;
   try {
-    const { ts, pin } = JSON.parse(
-      Buffer.from(session.value, "base64").toString()
-    );
-    const age = Date.now() / 1000 - ts;
-    // Timing-safe comparison for PIN
-    const expected = process.env.AUTH_PIN;
-    if (!expected || pin.length !== expected.length) return false;
-    let match = 0;
-    for (let i = 0; i < pin.length; i++) {
-      match |= pin.charCodeAt(i) ^ expected.charCodeAt(i);
-    }
-    return age < SESSION_DURATION && match === 0;
+    expectedSig = await signPayload(payload);
+  } catch {
+    return false;
+  }
+  if (!timingSafeEqual(providedSig, expectedSig)) return false;
+
+  try {
+    const { ts } = JSON.parse(base64urlDecodeToString(payload)) as {
+      ts?: number;
+    };
+    if (typeof ts !== "number") return false;
+    const age = Math.floor(Date.now() / 1000) - ts;
+    return age >= 0 && age < SESSION_DURATION;
   } catch {
     return false;
   }
 }
 
 /**
- * Verify PIN and return a session cookie value if correct.
+ * Verify PIN with constant-time compare and, on success, return a signed
+ * session cookie value. The returned value contains no secret material.
  */
-export function verifyPin(pin: string): string | null {
+export async function verifyPin(pin: string): Promise<string | null> {
   const correctPin = process.env.AUTH_PIN;
-  if (!correctPin || pin !== correctPin) return null;
+  if (!correctPin || typeof pin !== "string") return null;
+  if (!timingSafeEqual(pin, correctPin)) return null;
 
-  const payload = JSON.stringify({ ts: Math.floor(Date.now() / 1000), pin });
-  return Buffer.from(payload).toString("base64");
+  const payloadBytes = new TextEncoder().encode(
+    JSON.stringify({ ts: Math.floor(Date.now() / 1000) })
+  );
+  const payload = base64urlEncode(payloadBytes);
+  const sig = await signPayload(payload);
+  return `${payload}.${sig}`;
 }
 
 export { SESSION_COOKIE, SESSION_DURATION };


### PR DESCRIPTION
## Summary

First of three security PRs from a full-app audit. This one fixes the highest-severity issue: the session cookie embedded the PIN in plaintext (base64-encoded JSON) and was unsigned.

- HMAC-SHA256 signed session cookie (`payload.sig`); payload carries only the issued timestamp — no secret material.
- New `SESSION_SECRET` env var, with a fallback to an `AUTH_PIN`-derived key so existing deploys keep working.
- Per-IP login throttle (5 failures / 15 min) inside `/api/auth` POST to make online PIN brute-force impractical.
- `/api/auth` POST now guards malformed JSON instead of 500-ing.
- Logout overwrites the cookie with `maxAge: 0` for reliable clearing.

## Verification

- `npm run build` — clean (TypeScript + Next bundle).
- Standalone Web Crypto round-trip script (mirrors `src/lib/auth.ts`) — 8/8 cases pass:
  - happy-path verify
  - cookie body contains no PIN substring
  - wrong-secret signature rejected
  - payload tampering (forged ts) rejected
  - expired cookie rejected
  - empty / no-dot / dot-only malformed cookies rejected

## Notes for reviewer

- Existing sessions become invalid on deploy (different format). Expected — users re-enter their PIN once.
- Throttle is per-isolate (same caveat as `src/middleware.ts`). Good enough; a real distributed limiter would need KV/D1.
- PR 2 will add security headers (CSP, X-Frame-Options, etc.). PR 3 will add input limits + close info leaks.

## Test plan

- [ ] Set `SESSION_SECRET` (recommended) or rely on `AUTH_PIN`-derived fallback.
- [ ] Log in with the correct PIN → session cookie set, page loads.
- [ ] Inspect the cookie value — should be `<base64url>.<base64url>` with no PIN substring.
- [ ] Log in with a wrong PIN 5 times → 6th attempt returns 429.
- [ ] Log out → cookie cleared, subsequent `/api/history` returns 401.
- [ ] Tamper with the cookie payload → `/api/history` returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)