### PR TITLE
Security: HTTP security headers (PR 2/3)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,45 @@ const RATE_LIMIT_MAX_REQUESTS = 60; // 60 req/min for API routes
 const EXTERNAL_API_LIMIT = 10; // 10 req/min for external write API
 const MAP_LOAD_LIMIT = 100; // 100 page loads per minute (very generous)
 
+// ── Security headers ──
+//
+// CSP allows 'unsafe-inline' for script/style because Next App Router inlines
+// hydration scripts and Mapbox GL inlines styles; tightening that would
+// require a nonce pipeline. The other headers are unambiguous wins.
+//
+// Mapbox connects to api.mapbox.com (tiles + Directions) and events.mapbox.com
+// (telemetry). Tile/sprite/glyph assets live under *.tiles.mapbox.com.
+
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://*.mapbox.com https://*.tiles.mapbox.com",
+  "font-src 'self' data:",
+  "worker-src 'self' blob:",
+  "connect-src 'self' https://api.mapbox.com https://events.mapbox.com https://*.tiles.mapbox.com",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join("; ");
+
+function applySecurityHeaders(res: NextResponse): NextResponse {
+  res.headers.set("Content-Security-Policy", CSP);
+  res.headers.set("X-Content-Type-Options", "nosniff");
+  res.headers.set("X-Frame-Options", "DENY");
+  res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  res.headers.set(
+    "Permissions-Policy",
+    "geolocation=(self), camera=(), microphone=(), payment=(), usb=()"
+  );
+  res.headers.set(
+    "Strict-Transport-Security",
+    "max-age=31536000; includeSubDomains"
+  );
+  return res;
+}
+
 export function middleware(request: NextRequest) {
   const ip =
     request.headers.get("cf-connecting-ip") ??
@@ -28,15 +67,17 @@ export function middleware(request: NextRequest) {
   } else {
     entry.count++;
     if (entry.count > limit) {
-      return NextResponse.json(
-        { error: "Too many requests. Please slow down." },
-        {
-          status: 429,
-          headers: {
-            "Retry-After": "60",
-            "X-RateLimit-Limit": String(limit),
-          },
-        }
+      return applySecurityHeaders(
+        NextResponse.json(
+          { error: "Too many requests. Please slow down." },
+          {
+            status: 429,
+            headers: {
+              "Retry-After": "60",
+              "X-RateLimit-Limit": String(limit),
+            },
+          }
+        )
       );
     }
   }
@@ -47,7 +88,9 @@ export function middleware(request: NextRequest) {
     const botPatterns =
       /bot|crawl|spider|slurp|mediapartners|facebookexternalhit|bingpreview|semrush|ahrefs|mj12bot/i;
     if (botPatterns.test(ua)) {
-      return new NextResponse("Not available", { status: 403 });
+      return applySecurityHeaders(
+        new NextResponse("Not available", { status: 403 })
+      );
     }
   }
 
@@ -58,7 +101,7 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  return NextResponse.next();
+  return applySecurityHeaders(NextResponse.next());
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

PR 2/3 from the security audit. Adds standard HTTP security headers to every response from middleware (`/` + `/api/*`).

- `Content-Security-Policy` — narrows allowed origins to self + Mapbox (api/events/tiles). Still permits `'unsafe-inline'`/`'unsafe-eval'` because Next App Router inlines hydration scripts and Mapbox GL inlines styles. A stricter policy would need a nonce pipeline.
- `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` — clickjacking.
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy` — geolocation only to self; camera/mic/payment/usb denied.
- `Strict-Transport-Security: max-age=31536000; includeSubDomains`

Headers are also applied on the 429 and 403 short-circuit responses, not just the happy path.

## Verification

- `npm run build` — clean.
- Local `npm run dev` + `curl -D -`: all six headers present on `/` and `/api/health`.
- Stack-independent of PR 1; either PR can merge first.

## Test plan

- [ ] Load the app in a browser — map tiles render (CSP doesn't block Mapbox).
- [ ] Network tab on `/` shows the headers.
- [ ] Attempt to iframe the app from another origin — blocked.
- [ ] Geolocation prompt still works (geolocation=(self)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)