### PR TITLE
Security: input validation + info-leak fixes (PR 3/3)

### DIFF
--- a/src/app/api/courts/route.ts
+++ b/src/app/api/courts/route.ts
@@ -71,12 +71,11 @@ export async function GET(request: NextRequest) {
       }
     );
   } catch (error) {
+    // Log full error server-side; return a generic message to clients to
+    // avoid leaking upstream details (URLs, headers, stack hints).
     console.error("Failed to fetch courts:", error);
     return NextResponse.json(
-      {
-        error: "Failed to fetch court availability",
-        message: error instanceof Error ? error.message : "Unknown error",
-      },
+      { error: "Failed to fetch court availability" },
       { status: 502 }
     );
   }

--- a/src/app/api/directions/route.ts
+++ b/src/app/api/directions/route.ts
@@ -39,7 +39,11 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const locations = locationsParam.split("|").map((entry) => {
+  // Cap fan-out — each location triggers 2 Mapbox calls, so without a cap a
+  // single request can amplify into a large outbound burst.
+  const MAX_LOCATIONS = 50;
+  const rawEntries = locationsParam.split("|").slice(0, MAX_LOCATIONS);
+  const locations = rawEntries.map((entry) => {
     const [id, coords] = entry.split(":");
     if (!coords) return null;
     const [lat, lng] = coords.split(",").map(Number);

--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -2,8 +2,23 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth-guard";
 import { getFriends, addFriend, removeFriend } from "@/lib/db";
 
-/** GET /api/friends — list friends (public — shown on map) */
+// Friends carry personal data (home address + coordinates). Treat as
+// authenticated-only across all verbs, not just writes.
+
+const MAX_NAME = 100;
+const MAX_ADDRESS = 300;
+const MAX_EMOJI = 16;
+
+function sanitizeString(val: unknown, maxLen: number): string | undefined {
+  if (typeof val !== "string") return undefined;
+  const trimmed = val.slice(0, maxLen).trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** GET /api/friends — list friends (auth required) */
 export async function GET() {
+  const denied = await requireAuth();
+  if (denied) return denied;
   const friends = await getFriends();
   return NextResponse.json({ friends });
 }
@@ -13,25 +28,44 @@ export async function POST(request: NextRequest) {
   const denied = await requireAuth();
   if (denied) return denied;
 
-  const body = await request.json();
-  const { name, address, lat, lng, emoji } = body;
-
-  if (!name || !address || lat == null || lng == null) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
     return NextResponse.json(
-      { error: "Missing required fields: name, address, lat, lng" },
+      { error: "Invalid JSON body" },
       { status: 400 }
     );
   }
 
+  const name = sanitizeString(body.name, MAX_NAME);
+  const address = sanitizeString(body.address, MAX_ADDRESS);
+  const lat = Number(body.lat);
+  const lng = Number(body.lng);
+
+  if (!name || !address) {
+    return NextResponse.json(
+      { error: "Missing required fields: name, address" },
+      { status: 400 }
+    );
+  }
+  if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
+    return NextResponse.json(
+      { error: "Invalid lat" },
+      { status: 400 }
+    );
+  }
+  if (!Number.isFinite(lng) || lng < -180 || lng > 180) {
+    return NextResponse.json(
+      { error: "Invalid lng" },
+      { status: 400 }
+    );
+  }
+
+  const emoji = sanitizeString(body.emoji, MAX_EMOJI) ?? "👤";
+
   const id = crypto.randomUUID();
-  await addFriend({
-    id,
-    name,
-    address,
-    lat: Number(lat),
-    lng: Number(lng),
-    emoji: emoji || "👤",
-  });
+  await addFriend({ id, name, address, lat, lng, emoji });
 
   return NextResponse.json({ ok: true, id });
 }
@@ -41,7 +75,17 @@ export async function DELETE(request: NextRequest) {
   const denied = await requireAuth();
   if (denied) return denied;
 
-  const { id } = await request.json();
+  let body: { id?: unknown };
+  try {
+    body = (await request.json()) as { id?: unknown };
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const id = sanitizeString(body.id, 100);
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -2,6 +2,30 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth-guard";
 import { getPlayHistory, addPlayHistory, deletePlayHistory } from "@/lib/db";
 
+// Input caps mirror the external (API-key) route so a leaked PIN can't be
+// used to store unbounded blobs.
+const MAX_ID = 100;
+const MAX_NAME = 200;
+const MAX_COURT = 20;
+const MAX_TIME = 5;
+const MAX_NOTES = 1000;
+const MAX_FRIENDS = 20;
+const MAX_FRIEND_ID = 100;
+
+function asString(val: unknown, maxLen: number): string | undefined {
+  if (typeof val !== "string") return undefined;
+  const trimmed = val.slice(0, maxLen).trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asFriends(val: unknown): string[] {
+  if (!Array.isArray(val)) return [];
+  return val
+    .filter((v): v is string => typeof v === "string" && v.length > 0)
+    .slice(0, MAX_FRIENDS)
+    .map((v) => v.slice(0, MAX_FRIEND_ID));
+}
+
 /** GET /api/history — list play history (auth required) */
 export async function GET() {
   const denied = await requireAuth();
@@ -16,9 +40,16 @@ export async function POST(request: NextRequest) {
   const denied = await requireAuth();
   if (denied) return denied;
 
-  const body = await request.json();
-  const { locationId, locationName, courtNumber, date, time, friends, notes } =
-    body;
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const locationId = asString(body.locationId, MAX_ID);
+  const locationName = asString(body.locationName, MAX_NAME);
+  const date = asString(body.date, 10);
 
   if (!locationId || !locationName || !date) {
     return NextResponse.json(
@@ -26,17 +57,28 @@ export async function POST(request: NextRequest) {
       { status: 400 }
     );
   }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json(
+      { error: "Invalid date format, expected YYYY-MM-DD" },
+      { status: 400 }
+    );
+  }
+
+  const courtNumber = asString(body.courtNumber, MAX_COURT);
+  const time = asString(body.time, MAX_TIME);
+  const friends = asFriends(body.friends);
+  const notes = asString(body.notes, MAX_NOTES) ?? "";
 
   const id = crypto.randomUUID();
   await addPlayHistory({
     id,
     locationId,
     locationName,
-    courtNumber: courtNumber || null,
+    courtNumber: courtNumber ?? null,
     date,
-    time: time || null,
-    friends: friends || [],
-    notes: notes || "",
+    time: time ?? null,
+    friends,
+    notes,
   });
 
   return NextResponse.json({ ok: true, id });
@@ -47,7 +89,14 @@ export async function DELETE(request: NextRequest) {
   const denied = await requireAuth();
   if (denied) return denied;
 
-  const { id } = await request.json();
+  let body: { id?: unknown };
+  try {
+    body = (await request.json()) as { id?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const id = asString(body.id, MAX_ID);
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ export default function Home() {
   const travelTimes = useTravelTimes(rawCourts, userLocation);
   const auth = useAuth();
   const { favourites, toggleFavourite } = useFavourites();
-  const { friends, addFriend, removeFriend } = useFriends();
+  const { friends, addFriend, removeFriend } = useFriends(auth.authenticated);
   const { history, addEntry, deleteEntry } = useHistory(auth.authenticated);
 
   // UI state

--- a/src/hooks/useFriends.ts
+++ b/src/hooks/useFriends.ts
@@ -3,15 +3,20 @@
 import { useState, useEffect, useCallback } from "react";
 import type { Friend } from "@/types";
 
-export function useFriends() {
+export function useFriends(authenticated: boolean) {
   const [friends, setFriends] = useState<Friend[]>([]);
 
   useEffect(() => {
+    // GET is auth-gated; unauthenticated clients get 401 + no friends payload.
+    if (!authenticated) {
+      setFriends([]);
+      return;
+    }
     fetch("/api/friends")
-      .then((r) => r.json())
-      .then((d) => setFriends(d.friends))
+      .then((r) => (r.ok ? r.json() : { friends: [] }))
+      .then((d) => setFriends(Array.isArray(d.friends) ? d.friends : []))
       .catch(() => {});
-  }, []);
+  }, [authenticated]);
 
   const addFriend = useCallback(
     async (friend: {


### PR DESCRIPTION
## Summary

Final PR from the security audit.

- **Gate `/api/friends` GET** behind `requireAuth()`. Friends carry home address + coordinates — personal data that previously leaked to any unauthenticated viewer of the map. `useFriends` now takes an `authenticated` flag and refetches on login, mirroring `useHistory`.
- **Validate `/api/friends` and `/api/history` POST inputs.** The external API-key route already had length caps; the cookie-auth routes didn't. Adds name/address/notes length caps, friend-list count cap, lat/lng range checks, JSON-parse guards.
- **Cap `/api/directions` location count at 50.** Each entry fans out to 2 Mapbox calls; without a cap, one request could amplify into a large outbound burst.
- **Stop leaking error details from `/api/courts`** — was returning `error.message` to clients. Full error still logged server-side.

## Verification

- `npm run build` — clean.
- Dev-server probes:
  - `GET /api/friends` unauthenticated → 401 ✓
  - `POST /api/friends` unauthenticated → 401 ✓
  - `POST /api/history` unauthenticated → 401 ✓
  - `/api/directions?locations=…(200 entries)` is processed under the 50-cap.

## Stack order

Independent of PR 1 and PR 2; can merge in any order.

## Test plan

- [ ] Log in, then add a friend; verify it appears on the map.
- [ ] Log out, refresh — friends are no longer fetched.
- [ ] Try to POST a friend with `lat: 999` — 400.
- [ ] Try to POST history with `notes` of 5000 chars — accepted but stored truncated.
- [ ] Force an upstream rec.us failure and confirm the response no longer contains an internal message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)