### PR TITLE
fix: Cloudflare deploy/dev scripts can use stale or missing Worker output

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "typecheck": "tsc --noEmit",
     "start": "next start",
     "cf:build": "npx @opennextjs/cloudflare build",
+    "precf:dev": "npm run cf:build",
     "cf:dev": "npx wrangler dev",
+    "precf:deploy": "npm run cf:build",
     "cf:deploy": "npx wrangler deploy"
   },
   "keywords": [],


### PR DESCRIPTION
## PM TLDR

Fixes one Clawpatch finding: **Cloudflare deploy/dev scripts can use stale or missing Worker output**.

Closes #9

## What Changed

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-config-7528cb5b98-7a08d_2d5d97e7e2`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 14.91s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.09s |
| `build` | PASS | 11.06s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
