### PR TITLE
Harden Cloudflare deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,14 +3,35 @@ name: Deploy to Cloudflare Workers
 on:
   push:
     branches: [master]
+    paths:
+      - "package.json"
+      - "package-lock.json"
+      - "next.config.*"
+      - "open-next.config.*"
+      - "postcss.config.*"
+      - "tailwind.config.*"
+      - "tsconfig.json"
+      - "wrangler.json"
+      - "wrangler.toml"
+      - "public/**"
+      - "src/**"
+  workflow_dispatch:
+
+concurrency:
+  group: cloudflare-workers-production
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- add deploy path filters so docs-only and workflow-only changes do not publish
- add manual dispatch for intentional deploy checks
- add latest-only concurrency and a job timeout
- use least-privilege permissions and current checkout/setup-node actions

## Validation
- node /home/dev/dev/repos/ci-ops/scripts/workflow-policy-check.mjs .
- python3 YAML parse for .github/workflows/deploy.yml