### PR TITLE
fix: Other tools could misread whether the site is healthy

### DIFF
--- a/src/app/openapi.json/route.ts
+++ b/src/app/openapi.json/route.ts
@@ -113,7 +113,12 @@ const openapi = {
     schemas: {
       HealthResponse: {
         type: "object",
-        properties: { ok: { type: "boolean" } },
+        required: ["status", "timestamp", "runtime"],
+        properties: {
+          status: { type: "string", enum: ["ok"] },
+          timestamp: { type: "string", format: "date-time" },
+          runtime: { type: "string", enum: ["edge", "node"] },
+        },
       },
       CourtsResponse: {
         type: "object",


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The contract declares a HealthResponse object with only an `ok` boolean, but the implementation returns `status`, `timestamp`, and `runtime` and never returns `ok`. Generated clients and agent integrations following the advertised OpenAPI schema will reject or misread a successful health response.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Change HealthResponse to document `status` (for example enum [`ok`]), `timestamp` (date-time), and `runtime` (string), or change the handler to return the documented `ok` field. Keep the route and contract synchronized with a contract test.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #20



## What Changed

Finding: **Health endpoint OpenAPI schema does not match its response**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-b23aeb35c8-adad_d45a48c52a`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.14s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.5s |
| `build` | PASS | 11.01s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
