### PR TITLE
fix: Visitors could see travel times from their previous location

### DIFF
--- a/src/hooks/useTravelTimes.ts
+++ b/src/hooks/useTravelTimes.ts
@@ -59,13 +59,19 @@ export function useTravelTimes(
       .join("|");
 
     const originParam = `${origin.lat},${origin.lng}`;
+    const controller = new AbortController();
+    let cancelled = false;
 
-    fetch(`/api/directions?locations=${encodeURIComponent(locationsParam)}&origin=${encodeURIComponent(originParam)}`)
+    fetch(`/api/directions?locations=${encodeURIComponent(locationsParam)}&origin=${encodeURIComponent(originParam)}`, {
+      signal: controller.signal,
+    })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
       .then((data: { travelTimes: TravelTime[] }) => {
+        if (cancelled) return;
+
         const map = new Map(data.travelTimes.map((t) => [t.locationId, t]));
         setTravelTimes(map);
 
@@ -83,8 +89,14 @@ export function useTravelTimes(
         }
       })
       .catch((err) => {
+        if (cancelled) return;
         console.error("Failed to fetch travel times:", err);
       });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
   }, [courts, origin.lat, origin.lng]);
 
   return travelTimes;


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: Changing courts or origin starts another effect, but the prior fetch remains active and its success handler always writes state. An old route matrix can therefore overwrite travel times computed for the current origin or selected courts.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Abort the prior directions fetch in effect cleanup or guard state and cache writes with a current-request token.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #18



## What Changed

Finding: **Stale directions requests can overwrite travel times for a new origin or court list**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-63f3893f25-afa5_544ac90fe6`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.32s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.52s |
| `build` | PASS | 10.78s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
