### PR TITLE
fix: Court travel times stayed visible after the court list cleared

### DIFF
--- a/src/hooks/useTravelTimes.ts
+++ b/src/hooks/useTravelTimes.ts
@@ -33,7 +33,13 @@ export function useTravelTimes(
   );
 
   useEffect(() => {
-    if (courts.length === 0) return;
+    if (courts.length === 0) {
+      setTravelTimes(new Map());
+      return;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
 
     const courtIdStr = courts.map((c) => c.id).join(",");
     const key = cacheKey(origin, courtIdStr);
@@ -60,12 +66,16 @@ export function useTravelTimes(
 
     const originParam = `${origin.lat},${origin.lng}`;
 
-    fetch(`/api/directions?locations=${encodeURIComponent(locationsParam)}&origin=${encodeURIComponent(originParam)}`)
+    fetch(`/api/directions?locations=${encodeURIComponent(locationsParam)}&origin=${encodeURIComponent(originParam)}`, {
+      signal: controller.signal,
+    })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
       .then((data: { travelTimes: TravelTime[] }) => {
+        if (cancelled) return;
+
         const map = new Map(data.travelTimes.map((t) => [t.locationId, t]));
         setTravelTimes(map);
 
@@ -83,8 +93,14 @@ export function useTravelTimes(
         }
       })
       .catch((err) => {
+        if (cancelled) return;
         console.error("Failed to fetch travel times:", err);
       });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
   }, [courts, origin.lat, origin.lng]);
 
   return travelTimes;


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: When courts becomes empty, the effect returns without clearing travelTimes. The hook consequently returns travel times from the last non-empty selection even though there are no current courts to associate them with.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Before returning for an empty court list, set travelTimes to a new empty Map and cancel any prior request.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #17



## What Changed

Finding: **Clearing the court list leaves obsolete travel times visible**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-63f3893f25-47b3_f3b1deca18`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.51s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.56s |
| `build` | PASS | 11.17s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
