### PR TITLE
fix: People could see courts for the city or sport they just left

### DIFF
--- a/src/hooks/useCourts.ts
+++ b/src/hooks/useCourts.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { CourtLocation } from "@/types";
 import type { Sport, CityId } from "@/lib/constants";
 
@@ -17,25 +17,33 @@ export function useCourts(sport: Sport = "tennis", city: CityId = "sf"): CourtsD
   const [fetchedAt, setFetchedAt] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const latestRequestId = useRef(0);
 
   const fetchCourts = useCallback(async () => {
+    const requestId = ++latestRequestId.current;
     setLoading(true);
     setError(null);
     try {
       const res = await fetch(`/api/courts?sport=${sport}&city=${city}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
+      if (requestId !== latestRequestId.current) return;
       setCourts(data.courts);
       setFetchedAt(data.fetchedAt);
     } catch (err) {
+      if (requestId !== latestRequestId.current) return;
       setError(err instanceof Error ? err.message : "Failed to load courts");
     } finally {
+      if (requestId !== latestRequestId.current) return;
       setLoading(false);
     }
   }, [sport, city]);
 
   useEffect(() => {
     fetchCourts();
+    return () => {
+      latestRequestId.current += 1;
+    };
   }, [fetchCourts]);
 
   return { courts, fetchedAt, loading, error, refresh: fetchCourts };


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The hook starts a new request whenever sport or city changes, but neither aborts the prior request nor verifies that a response belongs to the latest request. A slower earlier response can call setCourts and setFetchedAt after the current request completes, displaying results for the previous selection.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Use an AbortController with effect cleanup, or associate each request with a monotonically increasing request ID and only commit results from the latest ID.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #16



## What Changed

Finding: **Out-of-order court responses can replace the current city or sport**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-63f3893f25-2275_99a7019df2`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.42s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.03s |
| `build` | PASS | 10.61s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
