### PR TITLE
fix: Refreshing availability could hide all open booking times

### DIFF
--- a/src/components/SlotGrid.tsx
+++ b/src/components/SlotGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import type { Court, TimeSlot } from "@/types";
 
 interface SlotGridProps {
@@ -22,6 +22,12 @@ export function SlotGrid({ courts }: SlotGridProps) {
   const [selectedDate, setSelectedDate] = useState<string>(
     allDates[0] ?? getTodaySF()
   );
+
+  useEffect(() => {
+    if (!allDates.includes(selectedDate)) {
+      setSelectedDate(allDates[0] ?? getTodaySF());
+    }
+  }, [allDates, selectedDate]);
 
   if (allDates.length === 0) {
     return (


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: selectedDate is initialized only on mount from allDates. When refreshed courts replace the available-date set, the retained date can be absent; every court then filters to zero slots while the newly rendered date tabs have no selected tab.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** When allDates changes, reset selectedDate if it is no longer included (prefer the first available date); also consider selecting the first available date when the prior selection becomes empty.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #15



## What Changed

Finding: **Slot selection can become invalid after availability refreshes**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-2cd56f3022-01f5_97d17ba1ad`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.37s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 3.96s |
| `build` | PASS | 10.38s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
