### PR TITLE
fix: Site updates could fail to reach visitors after a publishing change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
     paths:
+      - ".github/workflows/deploy.yml"
       - "package.json"
       - "package-lock.json"
       - "next.config.*"


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The push trigger is restricted to application and build-config paths, but excludes .github/workflows/deploy.yml. A change to the deployment command, action configuration, permissions, or build environment can merge without this workflow executing; the next unrelated application change is then the first deployment to exercise it.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Include .github/workflows/deploy.yml in the push paths, or remove path filtering if every master push should validate the production deployment workflow.

**How it was checked:** `npm ci` passed; `typecheck`, `build`, and `ci workflow policy` passed.

Closes #13



## What Changed

Finding: **Workflow-only changes do not run the deployment job**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-config-c0c75617bb-c07bc_4836158c1b`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 14.4s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 3.81s |
| `build` | PASS | 10.66s |
| `ci workflow policy` | PASS | 0.05s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
