### PR TITLE
fix: Availability errors could make courts look fully booked

### DIFF
--- a/src/app/openapi.json/route.ts
+++ b/src/app/openapi.json/route.ts
@@ -66,7 +66,8 @@ const openapi = {
             },
           },
           "502": {
-            description: "Upstream availability failed.",
+            description:
+              "An upstream availability request failed; no partial availability is returned.",
           },
         },
       },

--- a/src/lib/recus.test.ts
+++ b/src/lib/recus.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchAllCourts } from "./recus";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function bulkResponse(courtIds: string[]) {
+  return [
+    {
+      location: {
+        id: "location-1",
+        name: "Test courts",
+        lat: "37.77",
+        lng: "-122.42",
+        courts: courtIds.map((id, index) => ({
+          id,
+          courtNumber: String(index + 1),
+          sports: [{ sportId: "tennis" }],
+          config: { pricing: { default: { cents: 0 } } },
+          allowedReservationDurations: { minutes: [60] },
+          defaultReservationWindowDays: 7,
+          reservationReleaseTimeLocal: "08:00:00",
+        })),
+      },
+      formattedAddress: "1 Test St",
+      hoursOfOperation: "",
+      accessInfo: "",
+      gettingThereInfo: "",
+      images: {},
+    },
+  ];
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchAllCourts", () => {
+  it("treats a successful response with no slots as confirmed full availability", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(bulkResponse(["court-1"])))
+      .mockResolvedValueOnce(jsonResponse({ data: {} }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const locations = await fetchAllCourts("test-organization");
+
+    expect(locations[0].availabilityStatus).toBe("full");
+    expect(locations[0].courts[0].availableSlots).toEqual([]);
+  });
+
+  it("rejects mixed per-court results instead of reporting a failed court as full", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(bulkResponse(["court-empty", "court-failed"]))
+      )
+      .mockResolvedValueOnce(jsonResponse({ data: {} }))
+      .mockResolvedValueOnce(
+        new Response(null, { status: 500, statusText: "Internal Server Error" })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchAllCourts("test-organization")).rejects.toThrow(
+      "rec.us per-site API error for court court-failed"
+    );
+  });
+});

--- a/src/lib/recus.ts
+++ b/src/lib/recus.ts
@@ -54,24 +54,24 @@ export async function fetchAllCourts(orgSlug?: string): Promise<CourtLocation[]>
     const batch = allCourts.slice(i, i + BATCH_SIZE);
     const results = await Promise.all(
       batch.map(async ({ courtId }) => {
-        try {
-          const url = `${RECUS_API_BASE}/v1/sites/${courtId}/availability?startDate=${startDate}&endDate=${endDate}`;
-          const res = await fetch(url, { headers: RECUS_HEADERS });
-          if (!res.ok) return { courtId, slots: [] as string[] };
-
-          const data = await res.json();
-          const slots: string[] = [];
-
-          // data.data is { "2026-03-30": { "13:30:00": { availableDurationsMinutes: [...] } } }
-          for (const [date, times] of Object.entries(data.data || {})) {
-            for (const time of Object.keys(times as Record<string, unknown>)) {
-              slots.push(`${date} ${time.slice(0, 5)}`);
-            }
-          }
-          return { courtId, slots: slots.sort() };
-        } catch {
-          return { courtId, slots: [] as string[] };
+        const url = `${RECUS_API_BASE}/v1/sites/${courtId}/availability?startDate=${startDate}&endDate=${endDate}`;
+        const res = await fetch(url, { headers: RECUS_HEADERS });
+        if (!res.ok) {
+          throw new Error(
+            `rec.us per-site API error for court ${courtId}: ${res.status} ${res.statusText}`
+          );
         }
+
+        const data = await res.json();
+        const slots: string[] = [];
+
+        // data.data is { "2026-03-30": { "13:30:00": { availableDurationsMinutes: [...] } } }
+        for (const [date, times] of Object.entries(data.data || {})) {
+          for (const time of Object.keys(times as Record<string, unknown>)) {
+            slots.push(`${date} ${time.slice(0, 5)}`);
+          }
+        }
+        return { courtId, slots: slots.sort() };
       })
     );
 
@@ -97,7 +97,10 @@ function transformLocation(
 
   const courts: Court[] = loc.courts.map((c) => {
     // Use per-site availability (accurate) instead of bulk availableSlots
-    const realSlots = siteAvailability.get(c.id) || [];
+    const realSlots = siteAvailability.get(c.id);
+    if (!realSlots) {
+      throw new Error(`Missing per-site availability for court ${c.id}`);
+    }
 
     const slots: TimeSlot[] = realSlots.map((s) => ({
       datetime: s,


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: A non-OK response or exception from any per-site request is converted to an empty slot list. Transformation then treats that empty list as authoritative and may label the court or location `full`. This makes upstream outages indistinguishable from confirmed unavailability and contradicts the published automation guidance that API failures must be reported rather than availability invented.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Track per-site success separately from slot data. Either fail the assembled request when accurate availability is incomplete or expose an explicit unknown/partial status so consumers cannot interpret failures as bookings.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #44



## What Changed

Finding: **Per-court API failures are reported as genuine full availability**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-fd49585146-9788_a6bada9e07`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.39s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.7s |
| `build` | PASS | 11.12s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
