### PR TITLE
fix: Anyone could get around page limits and flood the site

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+
+import { middleware } from "./middleware";
+
+describe.each([
+  ["home page", "/", "192.0.2.1"],
+  ["docs page", "/docs", "192.0.2.2"],
+])("Markdown rate limiting for the %s", (_name, pathname, ip) => {
+  it("rejects requests after the page limit is reached", () => {
+    const request = () =>
+      new NextRequest(`https://tennis.marvinaziz.de${pathname}`, {
+        headers: {
+          Accept: "text/markdown",
+          "cf-connecting-ip": ip,
+        },
+      });
+
+    for (let count = 0; count < 100; count++) {
+      const response = middleware(request());
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe(
+        "text/markdown; charset=utf-8",
+      );
+    }
+
+    const response = middleware(request());
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("60");
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -85,11 +85,6 @@ export function middleware(request: NextRequest) {
   const limit = isApi ? RATE_LIMIT_MAX_REQUESTS : MAP_LOAD_LIMIT;
   const key = `${ip}:${isApi ? "api" : "page"}`;
 
-  if (acceptsMarkdown(request)) {
-    if (isPage) return markdownResponse(HOME_MARKDOWN);
-    if (isDocs) return markdownResponse(DOCS_MARKDOWN);
-  }
-
   const now = Date.now();
   const entry = rateLimitMap.get(key);
 
@@ -118,6 +113,11 @@ export function middleware(request: NextRequest) {
     for (const [k, v] of rateLimitMap.entries()) {
       if (now > v.resetAt) rateLimitMap.delete(k);
     }
+  }
+
+  if (acceptsMarkdown(request)) {
+    if (isPage) return markdownResponse(HOME_MARKDOWN);
+    if (isDocs) return markdownResponse(DOCS_MARKDOWN);
   }
 
   const response = applySecurityHeaders(NextResponse.next());


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: Requests for `/` or `/docs` that include `text/markdown` return before the rate-limit counter is read or incremented. Consequently, the documented page-load limit can be bypassed simply by selecting the Markdown representation, allowing unlimited requests to those routes from one IP.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Perform rate-limit accounting before content negotiation, then generate either the Markdown response or the normal response after the request has been admitted.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #40



## What Changed

Finding: **Markdown representations bypass page rate limiting**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-f8bf0b65a1-007b_f5c3c8e4ca`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.9s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.28s |
| `build` | PASS | 11.38s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
