### PR TITLE
fix: Automation could mistake the docs page for a working integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,7 @@ commands that are not in `package.json`.
 - `/docs` - documentation page.
 - `/docs.md`, `/llms.txt`, `/llm.txt` - text documentation for agents/tools.
 - `/openapi.json` - OpenAPI 3.1 contract.
-- `/.well-known/api-catalog`, `/.well-known/agent.json`,
-  `/.well-known/agent-card.json`, `/.well-known/agent-skills/index.json`, and
+- `/.well-known/api-catalog`, `/.well-known/agent-skills/index.json`, and
   `/.well-known/agent-skills/sf-tennis/SKILL.md` - discovery metadata.
 - `/api/courts`, `/api/directions`, `/api/health` - public API routes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,7 @@ commands that are not in `package.json`.
 - `/docs` - documentation page.
 - `/docs.md`, `/llms.txt`, `/llm.txt` - text documentation for agents/tools.
 - `/openapi.json` - OpenAPI 3.1 contract.
-- `/.well-known/api-catalog`, `/.well-known/agent.json`,
-  `/.well-known/agent-card.json`, `/.well-known/agent-skills/index.json`, and
+- `/.well-known/api-catalog`, `/.well-known/agent-skills/index.json`, and
   `/.well-known/agent-skills/sf-tennis/SKILL.md` - discovery metadata.
 - `/api/courts`, `/api/directions`, `/api/health` - public API routes.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ small public API surface for users, agents, and scripts.
 | Agent guide | [`/llms.txt`](https://tennis.marvinaziz.de/llms.txt) | Compact integration starting point |
 | OpenAPI | [`/openapi.json`](https://tennis.marvinaziz.de/openapi.json) | Machine-readable API contract |
 | API catalog | [`/.well-known/api-catalog`](https://tennis.marvinaziz.de/.well-known/api-catalog) | RFC 9727 linkset discovery |
-| Agent card | [`/.well-known/agent.json`](https://tennis.marvinaziz.de/.well-known/agent.json) | Capability metadata |
 | Agent skills | [`/.well-known/agent-skills/index.json`](https://tennis.marvinaziz.de/.well-known/agent-skills/index.json) | Skill discovery |
 
 The homepage and docs also support Markdown content negotiation:

--- a/src/app/.well-known/agent.json/route.test.ts
+++ b/src/app/.well-known/agent.json/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { GET as getLegacyAgentCard } from "./route";
+import { GET as getLegacyAgentCardAlias } from "../agent-card.json/route";
+import { DISCOVERY_LINK_HEADER, LLMS_TXT } from "../../../lib/agent-readiness";
+
+describe("legacy agent-card routes", () => {
+  it.each([
+    ["/.well-known/agent.json", getLegacyAgentCard],
+    ["/.well-known/agent-card.json", getLegacyAgentCardAlias],
+  ])(
+    "retires %s instead of advertising the docs as an A2A endpoint",
+    async (_, get) => {
+      const response = get();
+      const body = await response.json();
+
+      expect(response.status).toBe(410);
+      expect(body).toEqual({
+        error: "A2A service unavailable",
+        message:
+          "SF Tennis does not implement an A2A service. Use its public API discovery documents instead.",
+        links: {
+          documentation: "https://tennis.marvinaziz.de/docs",
+          openapi: "https://tennis.marvinaziz.de/openapi.json",
+          apiCatalog: "https://tennis.marvinaziz.de/.well-known/api-catalog",
+          skills:
+            "https://tennis.marvinaziz.de/.well-known/agent-skills/index.json",
+        },
+      });
+      expect(body).not.toHaveProperty("protocolVersion");
+      expect(body).not.toHaveProperty("url");
+    },
+  );
+
+  it("does not advertise an agent card through supported discovery surfaces", () => {
+    expect(DISCOVERY_LINK_HEADER).not.toContain('rel="agent-card"');
+    expect(LLMS_TXT).not.toContain("/.well-known/agent.json");
+  });
+});

--- a/src/app/.well-known/agent.json/route.ts
+++ b/src/app/.well-known/agent.json/route.ts
@@ -2,46 +2,30 @@ import { SITE_URL } from "@/lib/agent-readiness";
 
 export const dynamic = "force-static";
 
-const agentCard = {
-  protocolVersion: "0.2.6",
-  name: "SF Tennis Agent Guide",
-  description:
-    "Discovery card for agents that help users find public tennis and pickleball courts with SF Tennis.",
-  url: `${SITE_URL}/docs`,
-  provider: {
-    organization: "Marvin Aziz",
-    url: "https://marvinaziz.de",
-  },
-  version: "1.0.0",
-  documentationUrl: `${SITE_URL}/docs`,
-  defaultInputModes: ["text/plain", "application/json"],
-  defaultOutputModes: ["text/plain", "application/json"],
-  capabilities: {
-    streaming: false,
-    pushNotifications: false,
-    stateTransitionHistory: false,
-  },
-  skills: [
-    {
-      id: "find-courts",
-      name: "Find public court availability",
-      description:
-        "Use the public courts API to find available tennis or pickleball slots in San Francisco or Mountain View.",
-      tags: ["tennis", "pickleball", "availability", "san-francisco", "mountain-view"],
-      examples: [
-        "Find open tennis courts in San Francisco tonight.",
-        "Plan a pickleball session in Mountain View this weekend.",
-      ],
-    },
-  ],
-};
-
 export function GET() {
-  return Response.json(agentCard, {
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, s-maxage=86400",
-      Link: '</.well-known/agent-skills/index.json>; rel="agent-skills"; type="application/json"',
+  return Response.json(
+    {
+      error: "A2A service unavailable",
+      message:
+        "SF Tennis does not implement an A2A service. Use its public API discovery documents instead.",
+      links: {
+        documentation: `${SITE_URL}/docs`,
+        openapi: `${SITE_URL}/openapi.json`,
+        apiCatalog: `${SITE_URL}/.well-known/api-catalog`,
+        skills: `${SITE_URL}/.well-known/agent-skills/index.json`,
+      },
     },
-  });
+    {
+      status: 410,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "public, max-age=3600, s-maxage=86400",
+        Link: [
+          '</openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"',
+          '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+          '</.well-known/agent-skills/index.json>; rel="agent-skills"; type="application/json"',
+        ].join(", "),
+      },
+    },
+  );
 }

--- a/src/lib/agent-readiness.ts
+++ b/src/lib/agent-readiness.ts
@@ -14,7 +14,6 @@ export const DISCOVERY_LINK_HEADER = [
   '</openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"',
   '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
   '</.well-known/agent-skills/index.json>; rel="agent-skills"; type="application/json"',
-  '</.well-known/agent.json>; rel="agent-card"; type="application/json"',
 ].join(", ");
 
 export const HOME_MARKDOWN = `# SF Tennis
@@ -127,7 +126,6 @@ Last updated: ${LAST_UPDATED}
 - OpenAPI: ${SITE_URL}/openapi.json
 - API catalog: ${SITE_URL}/.well-known/api-catalog
 - Skill discovery: ${SITE_URL}/.well-known/agent-skills/index.json
-- Capability card: ${SITE_URL}/.well-known/agent.json
 - GitHub: ${GITHUB_URL}
 - Project page: ${PROJECT_URL}
 


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The document identifies itself as protocol version 0.2.6 and publishes A2A capabilities, input modes, output modes, and skills, but its required `url` points to `/docs`. In an A2A agent card, that URL is the protocol service endpoint, not a human-readable documentation page. Clients discovering either agent-card route will therefore send protocol requests to the documentation route and fail interoperability.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Either point `url` at an implemented A2A protocol endpoint or stop presenting this document as an A2A agent card and publish only the API/skill discovery metadata appropriate to the application's actual interface. Keep `documentationUrl` pointed at `/docs`.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #38



## What Changed

Finding: **Agent card advertises the documentation page as the A2A service endpoint**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-f3a17b57c7-2052_e4a2a032df`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.94s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.77s |
| `build` | PASS | 12.73s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
