### PR TITLE
fix: Travel times could stall when checking many courts

### DIFF
--- a/src/app/api/directions/route.test.ts
+++ b/src/app/api/directions/route.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { GET } from "./route";
+
+describe("GET /api/directions", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("limits concurrent Mapbox calls for a maximum-size request", async () => {
+    vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const fetchMock = vi.fn(async () => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+
+      return new Response(
+        JSON.stringify({ routes: [{ duration: 600, distance: 1_000 }] }),
+        { status: 200 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const locations = Array.from(
+      { length: 50 },
+      (_, index) => `court-${index}:37.${index},-122.${index}`
+    ).join("|");
+    const request = new NextRequest(
+      `https://example.com/api/directions?locations=${encodeURIComponent(locations)}`
+    );
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.travelTimes).toHaveLength(50);
+    expect(body.travelTimes.map((item: { locationId: string }) => item.locationId))
+      .toEqual(Array.from({ length: 50 }, (_, index) => `court-${index}`));
+    expect(fetchMock).toHaveBeenCalledTimes(100);
+    expect(peakInFlight).toBeLessThanOrEqual(6);
+  });
+});

--- a/src/app/api/directions/route.ts
+++ b/src/app/api/directions/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { CITIES, DEFAULT_CITY, DIRECTIONS_CACHE_SECONDS } from "@/lib/constants";
 import type { TravelTime } from "@/types";
 
+// Each location makes two parallel calls, keeping the total in flight at six.
+const DIRECTIONS_LOCATION_CONCURRENCY = 3;
+
 /**
  * GET /api/directions?locations=id1:lat1,lng1|id2:lat2,lng2&origin=lat,lng
  *
@@ -58,8 +61,10 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const results: TravelTime[] = await Promise.all(
-    locations.map(async (loc) => {
+  const results = await mapWithConcurrency(
+    locations,
+    DIRECTIONS_LOCATION_CONCURRENCY,
+    async (loc): Promise<TravelTime> => {
       const transitUrl = `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLng}&destination=${loc.lat},${loc.lng}&travelmode=transit`;
 
       const [walking, driving] = await Promise.all([
@@ -73,7 +78,7 @@ export async function GET(request: NextRequest) {
         driving,
         transitUrl,
       };
-    })
+    }
   );
 
   return NextResponse.json(
@@ -84,6 +89,28 @@ export async function GET(request: NextRequest) {
       },
     }
   );
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await mapper(items[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
+  );
+
+  return results;
 }
 
 async function fetchMapboxDirections(


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The route accepts up to 50 locations and immediately processes every location through an outer Promise.all; each location starts walking and driving requests through another Promise.all. One inbound request therefore launches up to 100 simultaneous outbound requests. The cap limits total fan-out but not concurrency, so ordinary maximum-size requests can cause upstream throttling, consume substantial worker...

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Process locations with a small bounded concurrency limit, or use a provider-supported matrix/batch endpoint. Select the limit with the deployment platform's subrequest limits and Mapbox rate limits in mind.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #30



## What Changed

Finding: **Maximum-size directions requests launch 100 Mapbox calls concurrently**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-1cc86c29f0-1eea_17f31e67ae`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.3s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.39s |
| `build` | PASS | 11.55s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
