### PR TITLE
fix: The shorter agent guide address could break without warning

### DIFF
--- a/src/app/llm.txt/route.test.ts
+++ b/src/app/llm.txt/route.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "./route";
+import { LLMS_TXT } from "../../lib/agent-readiness";
+
+describe("GET /llm.txt", () => {
+  it("serves the agent guide as an alias of the canonical route", async () => {
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(LLMS_TXT);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=3600, s-maxage=86400",
+    );
+    expect(response.headers.get("Link")).toBe(
+      '</llms.txt>; rel="canonical"; type="text/markdown"',
+    );
+  });
+});


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The owned alias route independently defines its response body, content type, cache policy, and canonical Link header, but the included test exercises only the separate /llms.txt route. A regression in the alias route could therefore pass the current tests.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Add a colocated src/app/llm.txt/route.test.ts that invokes this GET handler and verifies the body, status, Content-Type, Cache-Control, and canonical Link header.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #37



## What Changed

Finding: **The /llm.txt alias has no direct route test**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-c246a56659-abdf_77356901bd`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.17s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.43s |
| `build` | PASS | 11.44s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
