### PR TITLE
fix: Connected tools could miss essential court and travel details

### DIFF
--- a/src/app/openapi.json/route.test.ts
+++ b/src/app/openapi.json/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "./route";
+
+describe("GET /openapi.json", () => {
+  it("marks guaranteed response fields as required", async () => {
+    const response = GET();
+    const document = await response.json();
+    const schemas = document.components.schemas;
+    const travelTime = schemas.DirectionsResponse.properties.travelTimes.items;
+
+    expect(schemas.CourtsResponse.required).toEqual([
+      "sport",
+      "city",
+      "fetchedAt",
+      "courts",
+    ]);
+    expect(schemas.Location.required).toEqual([
+      "id",
+      "name",
+      "lat",
+      "lng",
+      "address",
+      "courts",
+      "totalSlotsToday",
+      "totalSlotsWeek",
+      "availabilityStatus",
+    ]);
+    expect(schemas.Court.required).toEqual([
+      "id",
+      "sportId",
+      "availableSlots",
+    ]);
+    expect(schemas.Slot.required).toEqual(["date", "weather"]);
+    expect(schemas.Slot.properties.weather.type).toEqual(["object", "null"]);
+    expect(schemas.DirectionsResponse.required).toEqual(["travelTimes"]);
+    expect(travelTime.required).toEqual([
+      "locationId",
+      "walking",
+      "driving",
+      "transitUrl",
+    ]);
+    expect(schemas.TravelMode.required).toEqual([
+      "durationMinutes",
+      "distanceMeters",
+    ]);
+  });
+});

--- a/src/app/openapi.json/route.ts
+++ b/src/app/openapi.json/route.ts
@@ -123,6 +123,7 @@ const openapi = {
       },
       CourtsResponse: {
         type: "object",
+        required: ["sport", "city", "fetchedAt", "courts"],
         properties: {
           sport: { type: "string", enum: ["tennis", "pickleball"] },
           city: { type: "string", enum: ["sf", "mountain-view"] },
@@ -135,6 +136,17 @@ const openapi = {
       },
       Location: {
         type: "object",
+        required: [
+          "id",
+          "name",
+          "lat",
+          "lng",
+          "address",
+          "courts",
+          "totalSlotsToday",
+          "totalSlotsWeek",
+          "availabilityStatus",
+        ],
         properties: {
           id: { type: "string" },
           name: { type: "string" },
@@ -155,6 +167,7 @@ const openapi = {
       },
       Court: {
         type: "object",
+        required: ["id", "sportId", "availableSlots"],
         properties: {
           id: { type: "string" },
           name: { type: "string" },
@@ -167,21 +180,27 @@ const openapi = {
       },
       Slot: {
         type: "object",
+        required: ["date", "weather"],
         properties: {
           date: { type: "string" },
           startTime: { type: "string" },
           endTime: { type: "string" },
           price: { type: "number" },
-          weather: { type: "object", additionalProperties: true },
+          weather: {
+            type: ["object", "null"],
+            additionalProperties: true,
+          },
         },
       },
       DirectionsResponse: {
         type: "object",
+        required: ["travelTimes"],
         properties: {
           travelTimes: {
             type: "array",
             items: {
               type: "object",
+              required: ["locationId", "walking", "driving", "transitUrl"],
               properties: {
                 locationId: { type: "string" },
                 walking: { $ref: "#/components/schemas/TravelMode" },
@@ -194,6 +213,7 @@ const openapi = {
       },
       TravelMode: {
         type: ["object", "null"],
+        required: ["durationMinutes", "distanceMeters"],
         properties: {
           durationMinutes: { type: "number" },
           distanceMeters: { type: "number" },


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: Unlike HealthResponse, the CourtsResponse, Location, Court, Slot, DirectionsResponse, nested travel-time item, and TravelMode object schemas have no required arrays. Under OpenAPI 3.1, this means empty objects satisfy all of these schemas and generated clients will model core fields such as courts, travelTimes, locationId, and durationMinutes as optional. That substantially weakens the published machine-readable...

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Add required arrays for fields guaranteed by each endpoint and nested object. Leave only genuinely conditional fields optional, and document any nullable values explicitly.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #62



## What Changed

Finding: **Response schemas unintentionally make every payload field optional**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-route-66386a27cc-6525de_5197baf98a`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.48s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 3.09s |
| `build` | PASS | 12.52s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
