### PR TITLE
fix: Site availability monitoring could silently stop working

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+async function expectHealthResponse(expectedRuntime: "node" | "edge") {
+  const response = await GET();
+  const body = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(body).toEqual({
+    status: "ok",
+    timestamp: expect.any(String),
+    runtime: expectedRuntime,
+  });
+  expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+}
+
+describe("GET /api/health", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports the complete health contract in the Node runtime", async () => {
+    expect(globalThis).not.toHaveProperty("EdgeRuntime");
+
+    await expectHealthResponse("node");
+  });
+
+  it("reports the complete health contract in the Edge runtime", async () => {
+    vi.stubGlobal("EdgeRuntime", "edge-runtime");
+
+    await expectHealthResponse("edge");
+  });
+});


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The API catalog publicly advertises /api/health as the status endpoint, and the project has a runnable Vitest suite, but none of the included tests invokes the health handler. Regressions to its status code, JSON fields, ISO timestamp serialization, or Node-versus-Edge runtime reporting could therefore pass CI unnoticed.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Add a route test that invokes GET, verifies HTTP 200 and the complete JSON contract, validates that timestamp parses as an ISO date, and exercises runtime reporting both with and without a stubbed EdgeRuntime global.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #65



## What Changed

Finding: **Public health response has no direct contract or runtime-branch tests**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-route-7abb132882-26018d_bdf40d03aa`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.6s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.61s |
| `build` | PASS | 12.33s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
