### PR TITLE
fix: Availability updates no longer make court times briefly disappear

### DIFF
--- a/src/components/SlotGrid.test.ts
+++ b/src/components/SlotGrid.test.ts
@@ -1,0 +1,95 @@
+import { isValidElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Court } from "@/types";
+
+const storedSelection = vi.hoisted(() => ({ value: "2026-09-07" }));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    ...actual,
+    useEffect: vi.fn(),
+    useMemo: (factory: () => unknown) => factory(),
+    useState: () => [storedSelection.value, vi.fn()],
+  };
+});
+
+import { getEffectiveDate, SlotGrid } from "./SlotGrid";
+
+interface ElementProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+function getText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(getText).join("");
+  }
+  if (isValidElement<ElementProps>(node)) {
+    return getText(node.props.children);
+  }
+  return "";
+}
+
+function hasClass(node: ReactNode, className: string): boolean {
+  if (Array.isArray(node)) {
+    return node.some((child) => hasClass(child, className));
+  }
+  if (!isValidElement<ElementProps>(node)) {
+    return false;
+  }
+  return (
+    node.props.className?.includes(className) === true ||
+    hasClass(node.props.children, className)
+  );
+}
+
+describe("getEffectiveDate", () => {
+  it("uses the first available date when the stored selection is stale", () => {
+    expect(getEffectiveDate("2026-09-07", ["2026-09-08"])).toBe(
+      "2026-09-08"
+    );
+  });
+
+  it("preserves a selection that is still available", () => {
+    expect(
+      getEffectiveDate("2026-09-08", ["2026-09-08", "2026-09-09"])
+    ).toBe("2026-09-08");
+  });
+});
+
+describe("SlotGrid", () => {
+  it("renders newly available slots immediately when the stored selection is stale", () => {
+    const courts: Court[] = [
+      {
+        id: "court-1",
+        courtNumber: "1",
+        sportId: "tennis",
+        priceCentsPerHour: 0,
+        allowedDurations: [60],
+        reservationWindowDays: 7,
+        releaseTime: "08:00:00",
+        availableSlots: [
+          {
+            datetime: "2026-09-08 09:00:00",
+            date: "2026-09-08",
+            time: "09:00",
+          },
+        ],
+        bookingUrl: "https://example.com/book",
+      },
+    ];
+
+    const rendered = SlotGrid({ courts });
+    const text = getText(rendered);
+
+    expect(hasClass(rendered, "bg-blue-600 text-white")).toBe(true);
+    expect(text).toContain("09:00");
+    expect(text).not.toContain("No slots");
+  });
+});

--- a/src/components/SlotGrid.tsx
+++ b/src/components/SlotGrid.tsx
@@ -7,6 +7,15 @@ interface SlotGridProps {
   courts: Court[];
 }
 
+export function getEffectiveDate(
+  selectedDate: string,
+  allDates: readonly string[]
+): string {
+  return allDates.includes(selectedDate)
+    ? selectedDate
+    : allDates[0] ?? selectedDate;
+}
+
 export function SlotGrid({ courts }: SlotGridProps) {
   // Get all unique dates across all courts
   const allDates = useMemo(() => {
@@ -22,6 +31,7 @@ export function SlotGrid({ courts }: SlotGridProps) {
   const [selectedDate, setSelectedDate] = useState<string>(
     allDates[0] ?? getTodaySF()
   );
+  const effectiveDate = getEffectiveDate(selectedDate, allDates);
 
   useEffect(() => {
     if (!allDates.includes(selectedDate)) {
@@ -49,7 +59,7 @@ export function SlotGrid({ courts }: SlotGridProps) {
             0
           );
           const isToday = date === getTodaySF();
-          const isSelected = date === selectedDate;
+          const isSelected = date === effectiveDate;
 
           return (
             <button
@@ -76,7 +86,7 @@ export function SlotGrid({ courts }: SlotGridProps) {
       {/* Court slots for selected date */}
       {courts.map((court) => {
         const daySlots = court.availableSlots.filter(
-          (s) => s.date === selectedDate
+          (s) => s.date === effectiveDate
         );
 
         return (


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: When new `courts` props no longer contain `selectedDate`, the component first renders using that stale date. No tab is selected and each court receives an empty `daySlots` array. The effect corrects the state only after that render, producing a transient false “No slots” state during refreshes, city/sport changes, or date rollover.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Derive an effective date synchronously from `selectedDate` and `allDates` and use it for tab selection and slot filtering, while optionally synchronizing the stored selection afterward.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #59



## What Changed

Finding: **Slot grid briefly renders every court as unavailable when the available date set changes**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-4fa9878573-cc34_43e9b39257`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.53s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.85s |
| `build` | PASS | 12.01s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
