### PR TITLE
fix: People could tap location even when it was unavailable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@tailwindcss/postcss": "^4.2.2",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.7",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.2",
@@ -4529,6 +4530,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/supercluster": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.7",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { UserLocationStatus } from "@/hooks/useUserLocation";
+import { TopBar } from "./TopBar";
+
+function renderLocationButton(status: UserLocationStatus) {
+  const markup = renderToStaticMarkup(
+    <TopBar
+      loading={false}
+      hasData={true}
+      fetchedAt={null}
+      viewMode="map"
+      sport="tennis"
+      city="san-francisco"
+      courtCount={1}
+      userLocationStatus={status}
+      onRefresh={() => {}}
+      onRequestLocation={() => {}}
+      onToggleView={() => {}}
+      onShowSearch={() => {}}
+    />,
+  );
+  const label =
+    status === "requesting"
+      ? "Locating…"
+      : status === "resolved"
+        ? "My location"
+        : status === "denied"
+          ? "Location blocked"
+          : status === "unsupported"
+            ? "Location unavailable"
+            : "Use my location";
+
+  return markup.match(
+    new RegExp(`<button[^>]*aria-label="${label}"[^>]*>`),
+  )?.[0];
+}
+
+describe("TopBar location control", () => {
+  const disabledAttribute = /\sdisabled(?:=""|(?=\s|>))/;
+
+  it.each(["requesting", "unsupported"] satisfies UserLocationStatus[])(
+    "disables location requests while the status is %s",
+    (status) => {
+      expect(renderLocationButton(status)).toMatch(disabledAttribute);
+    },
+  );
+
+  it.each([
+    "idle",
+    "fallback",
+    "denied",
+    "resolved",
+  ] satisfies UserLocationStatus[])(
+    "allows location requests while the status is %s",
+    (status) => {
+      expect(renderLocationButton(status)).not.toMatch(disabledAttribute);
+    },
+  );
+});

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -104,7 +104,10 @@ export function TopBar({
 
           <button
             onClick={onRequestLocation}
-            disabled={userLocationStatus === "requesting"}
+            disabled={
+              userLocationStatus === "requesting" ||
+              userLocationStatus === "unsupported"
+            }
             aria-label={locationLabel}
             title={locationLabel}
             className={`px-2 py-1 text-xs rounded transition-colors disabled:opacity-50 ${


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: For `userLocationStatus === "unsupported"`, the control is labeled “Location unavailable” and styled with `cursor-not-allowed`, but its `disabled` condition covers only `requesting`. The browser therefore treats the unsupported control as enabled and clicking or activating it still invokes `onRequestLocation`.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Disable the button when the status is either `requesting` or `unsupported`; retain enabled retry behavior for `denied` only if that is intentional.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #58



## What Changed

Finding: **Unsupported geolocation is presented as disabled but remains operable**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-4fa9878573-5f8d_88444133cb`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.85s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.9s |
| `build` | PASS | 11.75s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
