### PR TITLE
fix: Future update times no longer appear as negative ages

### DIFF
--- a/src/components/TimeSince.test.ts
+++ b/src/components/TimeSince.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTimeSince } from "./TimeSince";
+
+describe("formatTimeSince", () => {
+  it("clamps future update times to zero seconds", () => {
+    const now = Date.parse("2026-09-07T12:00:00.000Z");
+
+    expect(formatTimeSince("2026-09-07T12:00:30.000Z", now)).toBe(
+      "0s ago"
+    );
+  });
+
+  it("uses a stable fallback for an invalid update time", () => {
+    expect(formatTimeSince("not-a-date")).toBe("recently");
+  });
+});

--- a/src/components/TimeSince.tsx
+++ b/src/components/TimeSince.tsx
@@ -2,6 +2,16 @@
 
 import { useState, useEffect } from "react";
 
+export function formatTimeSince(isoString: string, now = Date.now()) {
+  const timestamp = Date.parse(isoString);
+  if (!Number.isFinite(timestamp)) return "recently";
+
+  const seconds = Math.max(0, Math.round((now - timestamp) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
+  return `${Math.round(seconds / 3600)}h ago`;
+}
+
 export function TimeSince({ isoString }: { isoString: string }) {
   const [, setTick] = useState(0);
 
@@ -10,13 +20,7 @@ export function TimeSince({ isoString }: { isoString: string }) {
     return () => clearInterval(interval);
   }, []);
 
-  const seconds = Math.round(
-    (Date.now() - new Date(isoString).getTime()) / 1000
-  );
-  let label: string;
-  if (seconds < 60) label = `${seconds}s ago`;
-  else if (seconds < 3600) label = `${Math.round(seconds / 60)}m ago`;
-  else label = `${Math.round(seconds / 3600)}h ago`;
+  const label = formatTimeSince(isoString);
 
   return <span className="text-gray-500">Updated {label}</span>;
 }


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The elapsed value is not clamped or given a future-time branch. A timestamp ahead of the browser clock satisfies `seconds < 60` and renders text such as “Updated -30s ago”. Small client/server clock differences make this possible even with otherwise valid timestamps.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Clamp elapsed seconds to zero for update timestamps, or explicitly format future values. Also handle non-finite parsed timestamps with a stable fallback.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #57



## What Changed

Finding: **Future timestamps produce negative “ago” labels**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-4fa9878573-11cb_082fa36db5`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.16s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.69s |
| `build` | PASS | 12.14s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
