### PR TITLE
fix: Court-finding integrations could break without warning

### DIFF
--- a/src/app/openapi.json/route.test.ts
+++ b/src/app/openapi.json/route.test.ts
@@ -2,7 +2,71 @@ import { describe, expect, it } from "vitest";
 
 import { GET } from "./route";
 
+function collectLocalReferences(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(collectLocalReferences);
+  }
+
+  if (value === null || typeof value !== "object") {
+    return [];
+  }
+
+  return Object.entries(value).flatMap(([key, nestedValue]) => {
+    if (
+      key === "$ref" &&
+      typeof nestedValue === "string" &&
+      nestedValue.startsWith("#/")
+    ) {
+      return [nestedValue];
+    }
+
+    return collectLocalReferences(nestedValue);
+  });
+}
+
+function resolveLocalReference(document: unknown, reference: string): unknown {
+  return reference
+    .slice(2)
+    .split("/")
+    .map((segment) =>
+      decodeURIComponent(segment).replaceAll("~1", "/").replaceAll("~0", "~"),
+    )
+    .reduce<unknown>((value, segment) => {
+      if (value === null || typeof value !== "object" || !(segment in value)) {
+        return undefined;
+      }
+
+      return (value as Record<string, unknown>)[segment];
+    }, document);
+}
+
 describe("GET /openapi.json", () => {
+  it("publishes a resolvable API contract with its cache policy", async () => {
+    const response = GET();
+    const document = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/vnd.oai.openapi+json; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=3600, s-maxage=86400",
+    );
+    expect(document.openapi).toBe("3.1.0");
+    expect(document.servers).toEqual([{ url: "https://tennis.marvinaziz.de" }]);
+    expect(Object.keys(document.paths).sort()).toEqual([
+      "/api/courts",
+      "/api/directions",
+      "/api/health",
+    ]);
+
+    const references = collectLocalReferences(document);
+    expect(references.length).toBeGreaterThan(0);
+    for (const reference of references) {
+      expect(resolveLocalReference(document, reference), reference).toBeDefined();
+    }
+  });
+
   it("marks guaranteed response fields as required", async () => {
     const response = GET();
     const document = await response.json();


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The project has a runnable Vitest suite and neighboring metadata routes test their status, content type, cache policy, and body contract, but no included test exercises /openapi.json. A malformed document, broken reference, incorrect media type, or accidental route/cache regression could therefore ship without detection.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Add a route test that asserts status 200, the OpenAPI media type, cache policy, version, server URL, expected paths, and resolvable local schema references.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #34



## What Changed

Finding: **The OpenAPI route has no direct contract test**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-85c96bac93-d920_4d0a55f627`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 14.93s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.33s |
| `build` | PASS | 10.93s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
