### PR TITLE
fix: Anyone could get around traffic limits and flood the site

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,7 @@
+import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 import type { NextConfig } from "next";
+
+initOpenNextCloudflareForDev();
 
 const nextConfig: NextConfig = {
   // No next/image optimization (not supported on CF Workers)

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,7 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 import { middleware } from "./middleware";
+
+const { apiLimit, pageLimit } = vi.hoisted(() => ({
+  apiLimit: vi.fn(),
+  pageLimit: vi.fn(),
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: () => ({
+    env: {
+      API_RATE_LIMITER: { limit: apiLimit },
+      PAGE_RATE_LIMITER: { limit: pageLimit },
+    },
+  }),
+}));
+
+beforeEach(() => {
+  apiLimit.mockReset().mockResolvedValue({ success: true });
+  pageLimit.mockReset().mockResolvedValue({ success: true });
+});
 
 function requestWithAccept(accept: string): NextRequest {
   return new NextRequest("https://tennis.marvinaziz.de/docs", {
@@ -13,27 +32,38 @@ describe.each([
   ["home page", "/", "192.0.2.1"],
   ["docs page", "/docs", "192.0.2.2"],
 ])("Markdown rate limiting for the %s", (_name, pathname, ip) => {
-  it("rejects requests after the page limit is reached", () => {
-    const request = () =>
+  it("rejects requests denied by the shared page limiter", async () => {
+    pageLimit.mockResolvedValueOnce({ success: false });
+
+    const response = await middleware(
       new NextRequest(`https://tennis.marvinaziz.de${pathname}`, {
         headers: {
           Accept: "text/markdown",
           "cf-connecting-ip": ip,
         },
-      });
-
-    for (let count = 0; count < 100; count++) {
-      const response = middleware(request());
-      expect(response.status).toBe(200);
-      expect(response.headers.get("Content-Type")).toBe(
-        "text/markdown; charset=utf-8",
-      );
-    }
-
-    const response = middleware(request());
+      }),
+    );
 
     expect(response.status).toBe(429);
     expect(response.headers.get("Retry-After")).toBe("60");
+    expect(pageLimit).toHaveBeenCalledWith({ key: ip });
+  });
+});
+
+describe("middleware API rate limiting", () => {
+  it("uses the shared API limiter and rejects a denied request", async () => {
+    apiLimit.mockResolvedValueOnce({ success: false });
+
+    const response = await middleware(
+      new NextRequest("https://tennis.marvinaziz.de/api/courts", {
+        headers: { "cf-connecting-ip": "192.0.2.3" },
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("60");
+    expect(apiLimit).toHaveBeenCalledWith({ key: "192.0.2.3" });
+    expect(pageLimit).not.toHaveBeenCalled();
   });
 });
 
@@ -43,8 +73,8 @@ describe("middleware Markdown negotiation", () => {
     "text/html, text/markdown;q=0.5",
     "TEXT/MARKDOWN;Q=1",
     'text/markdown; profile="summary,compact"',
-  ])("serves Markdown for an accepted Markdown media range: %s", (accept) => {
-    const response = middleware(requestWithAccept(accept));
+  ])("serves Markdown for an accepted Markdown media range: %s", async (accept) => {
+    const response = await middleware(requestWithAccept(accept));
 
     expect(response.headers.get("Content-Type")).toBe(
       "text/markdown; charset=utf-8",
@@ -55,8 +85,8 @@ describe("middleware Markdown negotiation", () => {
     "text/markdown;q=0, text/html",
     "application/x-text/markdownish",
     "text/html",
-  ])("continues to the page when Markdown is not accepted: %s", (accept) => {
-    const response = middleware(requestWithAccept(accept));
+  ])("continues to the page when Markdown is not accepted: %s", async (accept) => {
+    const response = await middleware(requestWithAccept(accept));
 
     expect(response.headers.get("x-middleware-next")).toBe("1");
     expect(response.headers.get("Content-Type")).toBeNull();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { NextRequest, NextResponse } from "next/server";
 import {
   DISCOVERY_LINK_HEADER,
@@ -5,12 +6,17 @@ import {
   HOME_MARKDOWN,
 } from "./lib/agent-readiness";
 
-// Simple in-memory rate limiter (per-IP, resets on deploy)
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-
-const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
 const RATE_LIMIT_MAX_REQUESTS = 60; // 60 req/min for API routes
 const MAP_LOAD_LIMIT = 100; // 100 page loads per minute (very generous)
+
+interface RateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+interface RateLimitEnv extends CloudflareEnv {
+  API_RATE_LIMITER: RateLimitBinding;
+  PAGE_RATE_LIMITER: RateLimitBinding;
+}
 
 // ── Security headers ──
 //
@@ -116,7 +122,7 @@ function markdownResponse(markdown: string): NextResponse {
   );
 }
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const ip =
     request.headers.get("cf-connecting-ip") ??
     request.headers.get("x-forwarded-for")?.split(",")[0] ??
@@ -126,36 +132,23 @@ export function middleware(request: NextRequest) {
   const isPage = request.nextUrl.pathname === "/";
   const isDocs = request.nextUrl.pathname === "/docs";
   const limit = isApi ? RATE_LIMIT_MAX_REQUESTS : MAP_LOAD_LIMIT;
-  const key = `${ip}:${isApi ? "api" : "page"}`;
+  const env = getCloudflareContext().env as RateLimitEnv;
+  const rateLimiter = isApi ? env.API_RATE_LIMITER : env.PAGE_RATE_LIMITER;
+  const { success } = await rateLimiter.limit({ key: ip });
 
-  const now = Date.now();
-  const entry = rateLimitMap.get(key);
-
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-  } else {
-    entry.count++;
-    if (entry.count > limit) {
-      return applySecurityHeaders(
-        NextResponse.json(
-          { error: "Too many requests. Please slow down." },
-          {
-            status: 429,
-            headers: {
-              "Retry-After": "60",
-              "X-RateLimit-Limit": String(limit),
-            },
-          }
-        )
-      );
-    }
-  }
-
-  // Clean up old entries periodically (every 1000 requests)
-  if (Math.random() < 0.001) {
-    for (const [k, v] of rateLimitMap.entries()) {
-      if (now > v.resetAt) rateLimitMap.delete(k);
-    }
+  if (!success) {
+    return applySecurityHeaders(
+      NextResponse.json(
+        { error: "Too many requests. Please slow down." },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": "60",
+            "X-RateLimit-Limit": String(limit),
+          },
+        }
+      )
+    );
   }
 
   if (acceptsMarkdown(request)) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,24 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  "ratelimits": [
+    {
+      "name": "API_RATE_LIMITER",
+      "namespace_id": "814293169",
+      "simple": {
+        "limit": 60,
+        "period": 60
+      }
+    },
+    {
+      "name": "PAGE_RATE_LIMITER",
+      "namespace_id": "264836189",
+      "simple": {
+        "limit": 100,
+        "period": 60
+      }
+    }
+  ],
   "routes": [
     {
       "pattern": "tennis.marvinaziz.de/*",


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The limiter stores counters in module-local memory, while the package deploys the application as Cloudflare Workers. Separate worker isolates and restarted isolates do not share this map, so traffic distributed among instances receives an independent quota in each instance. The resulting effective limit can substantially exceed the advertised 60 API requests or 100 page requests per minute.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Use a deployment-wide rate-limiting facility such as Cloudflare's rate-limiting binding or a Durable Object. If this is intentionally only best-effort overload smoothing, stop presenting its values as enforceable per-IP limits and document that limitation.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #41



## What Changed

Finding: **In-memory counters cannot enforce a deployment-wide limit on Cloudflare Workers**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-library-f8bf0b65a1-cc80_b2932d16eb`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 14.98s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.61s |
| `build` | PASS | 12.13s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
