### PR TITLE
fix: Travel times no longer load forever when directions stall

### DIFF
--- a/src/app/api/directions/route.test.ts
+++ b/src/app/api/directions/route.test.ts
@@ -51,7 +51,7 @@ describe("GET /api/directions", () => {
     expect(peakInFlight).toBeLessThanOrEqual(6);
   });
 
-  it("finishes the batch when Mapbox requests stall", async () => {
+  it("returns a partial no-store response when a Mapbox request stalls", async () => {
     vi.useFakeTimers();
     vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
 
@@ -114,6 +114,7 @@ describe("GET /api/directions", () => {
     const response = await responsePromise;
     const body = await response.json();
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(body.travelTimes).toHaveLength(4);
     expect(body.travelTimes[0].walking).toBeNull();
     expect(body.travelTimes[0].driving).toEqual({
@@ -128,6 +129,63 @@ describe("GET /api/directions", () => {
     ).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(8);
     expect(peakInFlight).toBeLessThanOrEqual(6);
+  });
+
+  it("finishes a maximum-size stalled batch at the overall deadline", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
+
+    const fetchMock = vi.fn(
+      (_input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        if (!signal) return new Promise<Response>(() => {});
+
+        return new Promise<Response>((_resolve, reject) => {
+          const rejectAsAborted = () => reject(signal.reason);
+
+          if (signal.aborted) {
+            rejectAsAborted();
+          } else {
+            signal.addEventListener("abort", rejectAsAborted, { once: true });
+          }
+        });
+      }
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const locations = Array.from(
+      { length: 50 },
+      (_, index) => `court-${index}:37.${index},-122.${index}`
+    ).join("|");
+    const request = new NextRequest(
+      `https://example.com/api/directions?locations=${encodeURIComponent(locations)}`
+    );
+
+    const responsePromise = GET(request);
+    let settled = false;
+    void responsePromise.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.runAllTicks();
+    expect(settled).toBe(true);
+
+    const response = await responsePromise;
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body.travelTimes).toHaveLength(50);
+    expect(
+      body.travelTimes.every(
+        (item: { walking: unknown; driving: unknown }) =>
+          item.walking === null && item.driving === null
+      )
+    ).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(100);
   });
 
   it.each([

--- a/src/app/api/directions/route.test.ts
+++ b/src/app/api/directions/route.test.ts
@@ -5,11 +5,13 @@ import { GET } from "./route";
 
 describe("GET /api/directions", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
 
   it("limits concurrent Mapbox calls for a maximum-size request", async () => {
+    vi.useFakeTimers();
     vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
 
     let inFlight = 0;
@@ -18,7 +20,7 @@ describe("GET /api/directions", () => {
       inFlight += 1;
       peakInFlight = Math.max(peakInFlight, inFlight);
 
-      await new Promise((resolve) => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
       inFlight -= 1;
 
       return new Response(
@@ -36,7 +38,9 @@ describe("GET /api/directions", () => {
       `https://example.com/api/directions?locations=${encodeURIComponent(locations)}`
     );
 
-    const response = await GET(request);
+    const responsePromise = GET(request);
+    await vi.runAllTimersAsync();
+    const response = await responsePromise;
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -44,6 +48,85 @@ describe("GET /api/directions", () => {
     expect(body.travelTimes.map((item: { locationId: string }) => item.locationId))
       .toEqual(Array.from({ length: 50 }, (_, index) => `court-${index}`));
     expect(fetchMock).toHaveBeenCalledTimes(100);
+    expect(peakInFlight).toBeLessThanOrEqual(6);
+  });
+
+  it("finishes the batch when Mapbox requests stall", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+    let callCount = 0;
+    const fetchMock = vi.fn(
+      (_input: string | URL | Request, init?: RequestInit) => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+
+        callCount += 1;
+        if (callCount !== 1) {
+          inFlight -= 1;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ routes: [{ duration: 600, distance: 1_000 }] }),
+              { status: 200 }
+            )
+          );
+        }
+
+        const signal = init?.signal;
+        if (!signal) return new Promise<Response>(() => {});
+
+        return new Promise<Response>((_resolve, reject) => {
+          const rejectAsAborted = () => {
+            inFlight -= 1;
+            reject(signal.reason);
+          };
+
+          if (signal.aborted) {
+            rejectAsAborted();
+          } else {
+            signal.addEventListener("abort", rejectAsAborted, { once: true });
+          }
+        });
+      }
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const locations = Array.from(
+      { length: 4 },
+      (_, index) => `court-${index}:37.${index},-122.${index}`
+    ).join("|");
+    const request = new NextRequest(
+      `https://example.com/api/directions?locations=${encodeURIComponent(locations)}`
+    );
+
+    const responsePromise = GET(request);
+    await vi.advanceTimersByTimeAsync(5_000);
+    let settled = false;
+    void responsePromise.then(() => {
+      settled = true;
+    });
+    await vi.runAllTicks();
+
+    expect(settled).toBe(true);
+
+    const response = await responsePromise;
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.travelTimes).toHaveLength(4);
+    expect(body.travelTimes[0].walking).toBeNull();
+    expect(body.travelTimes[0].driving).toEqual({
+      durationMinutes: 10,
+      distanceMeters: 1_000,
+    });
+    expect(
+      body.travelTimes.slice(1).every(
+        (item: { walking: unknown; driving: unknown }) =>
+          item.walking !== null && item.driving !== null
+      )
+    ).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
     expect(peakInFlight).toBeLessThanOrEqual(6);
   });
 

--- a/src/app/api/directions/route.ts
+++ b/src/app/api/directions/route.ts
@@ -4,6 +4,8 @@ import type { TravelTime } from "@/types";
 
 // Each location makes two parallel calls, keeping the total in flight at six.
 const DIRECTIONS_LOCATION_CONCURRENCY = 3;
+const DIRECTIONS_REQUEST_TIMEOUT_MS = 5_000;
+const DIRECTIONS_BATCH_TIMEOUT_MS = 30_000;
 
 function isValidCoordinatePair(lat: number, lng: number): boolean {
   return (
@@ -89,25 +91,51 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const results = await mapWithConcurrency(
-    locations,
-    DIRECTIONS_LOCATION_CONCURRENCY,
-    async (loc): Promise<TravelTime> => {
-      const transitUrl = `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLng}&destination=${loc.lat},${loc.lng}&travelmode=transit`;
-
-      const [walking, driving] = await Promise.all([
-        fetchMapboxDirections(mapboxToken, originLat, originLng, loc.lat, loc.lng, "walking"),
-        fetchMapboxDirections(mapboxToken, originLat, originLng, loc.lat, loc.lng, "driving"),
-      ]);
-
-      return {
-        locationId: loc.id,
-        walking,
-        driving,
-        transitUrl,
-      };
-    }
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    DIRECTIONS_BATCH_TIMEOUT_MS
   );
+  let results: TravelTime[];
+  try {
+    results = await mapWithConcurrency(
+      locations,
+      DIRECTIONS_LOCATION_CONCURRENCY,
+      async (loc): Promise<TravelTime> => {
+        const transitUrl = `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLng}&destination=${loc.lat},${loc.lng}&travelmode=transit`;
+
+        const [walking, driving] = await Promise.all([
+          fetchMapboxDirections(
+            mapboxToken,
+            originLat,
+            originLng,
+            loc.lat,
+            loc.lng,
+            "walking",
+            controller.signal
+          ),
+          fetchMapboxDirections(
+            mapboxToken,
+            originLat,
+            originLng,
+            loc.lat,
+            loc.lng,
+            "driving",
+            controller.signal
+          ),
+        ]);
+
+        return {
+          locationId: loc.id,
+          walking,
+          driving,
+          transitUrl,
+        };
+      }
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
 
   return NextResponse.json(
     { travelTimes: results },
@@ -147,12 +175,25 @@ async function fetchMapboxDirections(
   originLng: number,
   destLat: number,
   destLng: number,
-  profile: "walking" | "driving"
+  profile: "walking" | "driving",
+  batchSignal: AbortSignal
 ): Promise<{ durationMinutes: number; distanceMeters: number } | null> {
+  const controller = new AbortController();
+  const abortForBatch = () => controller.abort();
+  if (batchSignal.aborted) {
+    abortForBatch();
+  } else {
+    batchSignal.addEventListener("abort", abortForBatch, { once: true });
+  }
+  const timeout = setTimeout(
+    () => controller.abort(),
+    DIRECTIONS_REQUEST_TIMEOUT_MS
+  );
+
   try {
     // Mapbox uses lng,lat order
     const url = `https://api.mapbox.com/directions/v5/mapbox/${profile}/${originLng},${originLat};${destLng},${destLat}?access_token=${token}&overview=false`;
-    const res = await fetch(url);
+    const res = await fetch(url, { signal: controller.signal });
 
     if (!res.ok) return null;
 
@@ -174,5 +215,8 @@ async function fetchMapboxDirections(
     };
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeout);
+    batchSignal.removeEventListener("abort", abortForBatch);
   }
 }

--- a/src/app/api/directions/route.ts
+++ b/src/app/api/directions/route.ts
@@ -7,6 +7,11 @@ const DIRECTIONS_LOCATION_CONCURRENCY = 3;
 const DIRECTIONS_REQUEST_TIMEOUT_MS = 5_000;
 const DIRECTIONS_BATCH_TIMEOUT_MS = 30_000;
 
+interface MapboxDirectionsResult {
+  route: TravelTime["walking"];
+  timedOut: boolean;
+}
+
 function isValidCoordinatePair(lat: number, lng: number): boolean {
   return (
     Number.isFinite(lat) &&
@@ -97,6 +102,7 @@ export async function GET(request: NextRequest) {
     DIRECTIONS_BATCH_TIMEOUT_MS
   );
   let results: TravelTime[];
+  let hadTimeout = false;
   try {
     results = await mapWithConcurrency(
       locations,
@@ -104,7 +110,7 @@ export async function GET(request: NextRequest) {
       async (loc): Promise<TravelTime> => {
         const transitUrl = `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLng}&destination=${loc.lat},${loc.lng}&travelmode=transit`;
 
-        const [walking, driving] = await Promise.all([
+        const [walkingResult, drivingResult] = await Promise.all([
           fetchMapboxDirections(
             mapboxToken,
             originLat,
@@ -125,10 +131,12 @@ export async function GET(request: NextRequest) {
           ),
         ]);
 
+        hadTimeout ||= walkingResult.timedOut || drivingResult.timedOut;
+
         return {
           locationId: loc.id,
-          walking,
-          driving,
+          walking: walkingResult.route,
+          driving: drivingResult.route,
           transitUrl,
         };
       }
@@ -141,7 +149,9 @@ export async function GET(request: NextRequest) {
     { travelTimes: results },
     {
       headers: {
-        "Cache-Control": `s-maxage=${DIRECTIONS_CACHE_SECONDS}, stale-while-revalidate=86400`,
+        "Cache-Control": hadTimeout
+          ? "no-store"
+          : `s-maxage=${DIRECTIONS_CACHE_SECONDS}, stale-while-revalidate=86400`,
       },
     }
   );
@@ -177,16 +187,23 @@ async function fetchMapboxDirections(
   destLng: number,
   profile: "walking" | "driving",
   batchSignal: AbortSignal
-): Promise<{ durationMinutes: number; distanceMeters: number } | null> {
+): Promise<MapboxDirectionsResult> {
   const controller = new AbortController();
-  const abortForBatch = () => controller.abort();
+  let timedOut = false;
+  const abortForBatch = () => {
+    timedOut = true;
+    controller.abort();
+  };
   if (batchSignal.aborted) {
     abortForBatch();
   } else {
     batchSignal.addEventListener("abort", abortForBatch, { once: true });
   }
   const timeout = setTimeout(
-    () => controller.abort(),
+    () => {
+      timedOut = true;
+      controller.abort();
+    },
     DIRECTIONS_REQUEST_TIMEOUT_MS
   );
 
@@ -195,26 +212,29 @@ async function fetchMapboxDirections(
     const url = `https://api.mapbox.com/directions/v5/mapbox/${profile}/${originLng},${originLat};${destLng},${destLat}?access_token=${token}&overview=false`;
     const res = await fetch(url, { signal: controller.signal });
 
-    if (!res.ok) return null;
+    if (!res.ok) return { route: null, timedOut };
 
     const data = await res.json();
     const route = data.routes?.[0];
-    if (!route) return null;
+    if (!route) return { route: null, timedOut };
     if (
       !Number.isFinite(route.duration) ||
       route.duration < 0 ||
       !Number.isFinite(route.distance) ||
       route.distance < 0
     ) {
-      return null;
+      return { route: null, timedOut };
     }
 
     return {
-      durationMinutes: Math.round(route.duration / 60),
-      distanceMeters: Math.round(route.distance),
+      route: {
+        durationMinutes: Math.round(route.duration / 60),
+        distanceMeters: Math.round(route.distance),
+      },
+      timedOut,
     };
   } catch {
-    return null;
+    return { route: null, timedOut };
   } finally {
     clearTimeout(timeout);
     batchSignal.removeEventListener("abort", abortForBatch);

--- a/src/hooks/useTravelTimes.test.ts
+++ b/src/hooks/useTravelTimes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldCacheTravelTimesResponse } from "./useTravelTimes";
+
+describe("shouldCacheTravelTimesResponse", () => {
+  it("does not cache responses marked no-store", () => {
+    const response = new Response(null, {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+
+    expect(shouldCacheTravelTimesResponse(response)).toBe(false);
+  });
+
+  it("allows caching for the normal directions response", () => {
+    const response = new Response(null, {
+      headers: { "Cache-Control": "s-maxage=86400" },
+    });
+
+    expect(shouldCacheTravelTimesResponse(response)).toBe(true);
+  });
+});

--- a/src/hooks/useTravelTimes.ts
+++ b/src/hooks/useTravelTimes.ts
@@ -12,6 +12,13 @@ interface CachedData {
   cachedAt: number;
 }
 
+export function shouldCacheTravelTimesResponse(response: Response): boolean {
+  return !response.headers
+    .get("Cache-Control")
+    ?.split(",")
+    .some((directive) => directive.trim().toLowerCase() === "no-store");
+}
+
 function cacheKey(origin: UserLocation, courtIds: string): string {
   // Round to ~100m precision so tiny GPS jitter doesn't bust the cache
   const lat = origin.lat.toFixed(3);
@@ -69,15 +76,20 @@ export function useTravelTimes(
     fetch(`/api/directions?locations=${encodeURIComponent(locationsParam)}&origin=${encodeURIComponent(originParam)}`, {
       signal: controller.signal,
     })
-      .then((res) => {
+      .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json();
+        return {
+          data: (await res.json()) as { travelTimes: TravelTime[] },
+          shouldCache: shouldCacheTravelTimesResponse(res),
+        };
       })
-      .then((data: { travelTimes: TravelTime[] }) => {
+      .then(({ data, shouldCache }) => {
         if (cancelled) return;
 
         const map = new Map(data.travelTimes.map((t) => [t.locationId, t]));
         setTravelTimes(map);
+
+        if (!shouldCache) return;
 
         // Cache in localStorage
         try {


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The outbound fetch has no AbortSignal or other timeout. Each worker awaits its current location before taking another, and GET awaits every worker. If either walking or driving fetch never settles, that worker stops progressing and Promise.all prevents the route from responding. On this public endpoint, repeated stalled requests can retain Worker resources until an external platform timeout.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Apply a bounded per-request timeout using an AbortSignal compatible with both the Next.js and Cloudflare runtimes. Continue returning null for a timed-out mode, while ensuring the overall request completes within a defined budget.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #87



## What Changed

Finding: **Mapbox calls have no deadline, so one stalled request can block the entire batch**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-route-da67b41996-a8a835_0ad8151446`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.06s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.78s |
| `build` | PASS | 12.04s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
