### PR TITLE
fix: Brief map outages could hide travel times for a full day

### DIFF
--- a/src/app/api/directions/route.test.ts
+++ b/src/app/api/directions/route.test.ts
@@ -175,5 +175,83 @@ describe("GET /api/directions", () => {
       durationMinutes: 10,
       distanceMeters: 1_001,
     });
+    expect(response.headers.get("Cache-Control")).toBe(
+      "s-maxage=86400, stale-while-revalidate=86400"
+    );
+  });
+
+  it("does not cache a response degraded by a Mapbox rate limit", async () => {
+    vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ routes: [{ duration: 600, distance: 1_000 }] }),
+        { status: 200 }
+      ))
+    );
+
+    const request = new NextRequest(
+      "https://example.com/api/directions?locations=court-1:37.75,-122.45"
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.travelTimes[0].walking).toBeNull();
+    expect(body.travelTimes[0].driving).not.toBeNull();
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("does not cache a response degraded by a Mapbox network failure", async () => {
+    vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
+    vi.stubGlobal("fetch", vi.fn()
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ routes: [{ duration: 600, distance: 1_000 }] }),
+        { status: 200 }
+      ))
+    );
+
+    const request = new NextRequest(
+      "https://example.com/api/directions?locations=court-1:37.75,-122.45"
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("does not cache a malformed successful Mapbox response", async () => {
+    vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    })));
+
+    const request = new NextRequest(
+      "https://example.com/api/directions?locations=court-1:37.75,-122.45"
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("keeps caching a definitive no-route response", async () => {
+    vi.stubEnv("MAPBOX_SECRET_TOKEN", "test-token");
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ code: "NoRoute", routes: [] }),
+    })));
+
+    const request = new NextRequest(
+      "https://example.com/api/directions?locations=court-1:37.75,-122.45"
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "s-maxage=86400, stale-while-revalidate=86400"
+    );
   });
 });

--- a/src/app/api/directions/route.ts
+++ b/src/app/api/directions/route.ts
@@ -5,6 +5,13 @@ import type { TravelTime } from "@/types";
 // Each location makes two parallel calls, keeping the total in flight at six.
 const DIRECTIONS_LOCATION_CONCURRENCY = 3;
 
+type RouteEstimate = NonNullable<TravelTime["walking"]>;
+
+interface MapboxDirectionsResult {
+  route: RouteEstimate | null;
+  cacheable: boolean;
+}
+
 function isValidCoordinatePair(lat: number, lng: number): boolean {
   return (
     Number.isFinite(lat) &&
@@ -92,7 +99,7 @@ export async function GET(request: NextRequest) {
   const results = await mapWithConcurrency(
     locations,
     DIRECTIONS_LOCATION_CONCURRENCY,
-    async (loc): Promise<TravelTime> => {
+    async (loc) => {
       const transitUrl = `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLng}&destination=${loc.lat},${loc.lng}&travelmode=transit`;
 
       const [walking, driving] = await Promise.all([
@@ -101,19 +108,26 @@ export async function GET(request: NextRequest) {
       ]);
 
       return {
-        locationId: loc.id,
-        walking,
-        driving,
-        transitUrl,
+        travelTime: {
+          locationId: loc.id,
+          walking: walking.route,
+          driving: driving.route,
+          transitUrl,
+        } satisfies TravelTime,
+        cacheable: walking.cacheable && driving.cacheable,
       };
     }
   );
 
+  const cacheable = results.every((result) => result.cacheable);
+
   return NextResponse.json(
-    { travelTimes: results },
+    { travelTimes: results.map((result) => result.travelTime) },
     {
       headers: {
-        "Cache-Control": `s-maxage=${DIRECTIONS_CACHE_SECONDS}, stale-while-revalidate=86400`,
+        "Cache-Control": cacheable
+          ? `s-maxage=${DIRECTIONS_CACHE_SECONDS}, stale-while-revalidate=86400`
+          : "no-store",
       },
     }
   );
@@ -148,31 +162,38 @@ async function fetchMapboxDirections(
   destLat: number,
   destLng: number,
   profile: "walking" | "driving"
-): Promise<{ durationMinutes: number; distanceMeters: number } | null> {
+): Promise<MapboxDirectionsResult> {
   try {
     // Mapbox uses lng,lat order
     const url = `https://api.mapbox.com/directions/v5/mapbox/${profile}/${originLng},${originLat};${destLng},${destLat}?access_token=${token}&overview=false`;
     const res = await fetch(url);
 
-    if (!res.ok) return null;
+    if (!res.ok) return { route: null, cacheable: false };
 
     const data = await res.json();
     const route = data.routes?.[0];
-    if (!route) return null;
+    if (!route) {
+      const definitiveNoRoute =
+        data.code === "NoRoute" || data.code === "NoSegment";
+      return { route: null, cacheable: definitiveNoRoute };
+    }
     if (
       !Number.isFinite(route.duration) ||
       route.duration < 0 ||
       !Number.isFinite(route.distance) ||
       route.distance < 0
     ) {
-      return null;
+      return { route: null, cacheable: false };
     }
 
     return {
-      durationMinutes: Math.round(route.duration / 60),
-      distanceMeters: Math.round(route.distance),
+      route: {
+        durationMinutes: Math.round(route.duration / 60),
+        distanceMeters: Math.round(route.distance),
+      },
+      cacheable: true,
     };
   } catch {
-    return null;
+    return { route: null, cacheable: false };
   }
 }

--- a/src/hooks/useTravelTimes.ts
+++ b/src/hooks/useTravelTimes.ts
@@ -69,15 +69,20 @@ export function useTravelTimes(
     fetch(`/api/directions?locations=${encodeURIComponent(locationsParam)}&origin=${encodeURIComponent(originParam)}`, {
       signal: controller.signal,
     })
-      .then((res) => {
+      .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json();
+        return {
+          data: await res.json() as { travelTimes: TravelTime[] },
+          cacheable: !res.headers.get("Cache-Control")?.includes("no-store"),
+        };
       })
-      .then((data: { travelTimes: TravelTime[] }) => {
+      .then(({ data, cacheable }) => {
         if (cancelled) return;
 
         const map = new Map(data.travelTimes.map((t) => [t.locationId, t]));
         setTravelTimes(map);
+
+        if (!cacheable) return;
 
         // Cache in localStorage
         try {


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: Every non-2xx response, network error, JSON error, or invalid Mapbox payload becomes null, but GET still returns HTTP 200 with the normal shared-cache policy. The documented cache duration is 24 hours, so a rate limit or brief provider outage can persist null walking/driving results long after Mapbox recovers. Preserving null for an individual unavailable route is compatible with the tests; applying the success TTL...

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Track whether either Mapbox lookup failed because of an upstream or transport error. Return degraded data with no-store or a short retry-oriented TTL, or return a retryable 502/503 when all lookups fail. Keep the long shared-cache TTL only for successfully resolved responses and definitive no-route results.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #86



## What Changed

Finding: **Transient Mapbox failures are cached as successful travel results for 24 hours**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-route-da67b41996-873e71_a597a8606a`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.03s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 3.16s |
| `build` | PASS | 12.27s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
