### PR TITLE
fix: Typos could show availability for the wrong sport or city

### DIFF
--- a/src/app/api/courts/route.test.ts
+++ b/src/app/api/courts/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { fetchAllCourts } from "@/lib/recus";
+import { enrichCourtsWithWeather } from "@/lib/weather";
+import { GET } from "./route";
+
+vi.mock("@/lib/recus", () => ({
+  fetchAllCourts: vi.fn(),
+}));
+
+vi.mock("@/lib/weather", () => ({
+  enrichCourtsWithWeather: vi.fn(),
+}));
+
+describe("GET /api/courts", () => {
+  beforeEach(() => {
+    vi.mocked(fetchAllCourts).mockReset().mockResolvedValue([]);
+    vi.mocked(enrichCourtsWithWeather)
+      .mockReset()
+      .mockImplementation(async (courts) => courts);
+  });
+
+  it("uses the documented defaults when query parameters are omitted", async () => {
+    const response = await GET(
+      new NextRequest("https://example.com/api/courts")
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      sport: "tennis",
+      city: "sf",
+      courts: [],
+    });
+    expect(fetchAllCourts).toHaveBeenCalledWith("san-francisco-rec-park");
+  });
+
+  it.each([
+    ["tennis", "sf", "san-francisco-rec-park"],
+    ["pickleball", "mountain-view", "city-of-mountain-view"],
+  ])(
+    "accepts sport=%s and city=%s",
+    async (sport, city, expectedCitySlug) => {
+      const response = await GET(
+        new NextRequest(
+          `https://example.com/api/courts?sport=${sport}&city=${city}`
+        )
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ sport, city, courts: [] });
+      expect(fetchAllCourts).toHaveBeenCalledWith(expectedCitySlug);
+    }
+  );
+
+  it.each(["pickelball", "", "TENNIS"])(
+    "rejects invalid sport=%s without fetching availability",
+    async (sport) => {
+      const response = await GET(
+        new NextRequest(
+          `https://example.com/api/courts?sport=${encodeURIComponent(sport)}`
+        )
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: "Invalid 'sport' parameter",
+      });
+      expect(fetchAllCourts).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["mountainview", "", "toString", "constructor", "__proto__"])(
+    "rejects invalid city=%s without fetching availability",
+    async (city) => {
+      const response = await GET(
+        new NextRequest(
+          `https://example.com/api/courts?city=${encodeURIComponent(city)}`
+        )
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: "Invalid 'city' parameter",
+      });
+      expect(fetchAllCourts).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/app/api/courts/route.ts
+++ b/src/app/api/courts/route.ts
@@ -20,12 +20,31 @@ const SPORT_IDS: Record<Sport, string> = {
  */
 export async function GET(request: NextRequest) {
   try {
-    const sportParam = request.nextUrl.searchParams.get("sport") as Sport | null;
-    const sport: Sport = sportParam === "pickleball" ? "pickleball" : "tennis";
+    const sportParam = request.nextUrl.searchParams.get("sport");
+    if (
+      sportParam !== null &&
+      sportParam !== "tennis" &&
+      sportParam !== "pickleball"
+    ) {
+      return NextResponse.json(
+        { error: "Invalid 'sport' parameter" },
+        { status: 400 }
+      );
+    }
+    const sport: Sport = sportParam ?? "tennis";
     const sportId = SPORT_IDS[sport];
 
-    const cityParam = request.nextUrl.searchParams.get("city") as CityId | null;
-    const cityId: CityId = cityParam && cityParam in CITIES ? cityParam : DEFAULT_CITY;
+    const cityParam = request.nextUrl.searchParams.get("city");
+    if (
+      cityParam !== null &&
+      !Object.prototype.hasOwnProperty.call(CITIES, cityParam)
+    ) {
+      return NextResponse.json(
+        { error: "Invalid 'city' parameter" },
+        { status: 400 }
+      );
+    }
+    const cityId: CityId = cityParam ?? DEFAULT_CITY;
     const city = CITIES[cityId];
 
     const allCourts = await fetchAllCourts(city.slug);

--- a/src/app/openapi.json/route.test.ts
+++ b/src/app/openapi.json/route.test.ts
@@ -117,5 +117,13 @@ describe("GET /openapi.json", () => {
       "durationMinutes",
       "distanceMeters",
     ]);
+
+    const invalidCourtsRequest = document.paths["/api/courts"].get.responses["400"]
+      .content["application/json"].schema;
+    expect(invalidCourtsRequest.required).toEqual(["error"]);
+    expect(invalidCourtsRequest.properties.error.enum).toEqual([
+      "Invalid 'sport' parameter",
+      "Invalid 'city' parameter",
+    ]);
   });
 });

--- a/src/app/openapi.json/route.ts
+++ b/src/app/openapi.json/route.ts
@@ -65,6 +65,26 @@ const openapi = {
               },
             },
           },
+          "400": {
+            description: "The requested sport or city is not supported.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["error"],
+                  properties: {
+                    error: {
+                      type: "string",
+                      enum: [
+                        "Invalid 'sport' parameter",
+                        "Invalid 'city' parameter",
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
           "502": {
             description:
               "An upstream availability request failed; no partial availability is returned.",


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The documented query parameters have closed sets of supported values, but any supplied sport other than "pickleball" is treated as tennis and any unrecognized city is treated as the default city. A typo such as sport=pickelball or city=mountainview therefore produces a successful response containing different availability than requested. This is especially hazardous for agents and scripts because the response looks...

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Distinguish omitted parameters from invalid parameters. Preserve the current defaults when a parameter is absent, but return HTTP 400 with a stable error body when a supplied sport or city is outside the documented enum. Use an own-property check for city membership rather than the prototype-inclusive `in` operator.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #84



## What Changed

Finding: **Unsupported query values silently return data for a different sport or city**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-route-cbaa29ac03-a56445_42f8a74b0f`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.98s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.82s |
| `build` | PASS | 12.58s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
