### PR TITLE
fix: Courts with no open times were mistakenly shown as unavailable

### DIFF
--- a/src/components/SlotGrid.test.ts
+++ b/src/components/SlotGrid.test.ts
@@ -64,6 +64,29 @@ describe("getEffectiveDate", () => {
 });
 
 describe("SlotGrid", () => {
+  it("describes empty availability without inventing a booking policy", () => {
+    const courts: Court[] = [
+      {
+        id: "court-1",
+        courtNumber: "1",
+        sportId: "tennis",
+        priceCentsPerHour: 0,
+        allowedDurations: [60],
+        reservationWindowDays: 5,
+        releaseTime: "09:00:00",
+        availableSlots: [],
+        bookingUrl: "https://example.com/book",
+      },
+    ];
+
+    const text = getText(SlotGrid({ courts }));
+
+    expect(text).toContain("No bookable slots available this week");
+    expect(text).not.toContain("No courts available");
+    expect(text).not.toContain("7 days");
+    expect(text).not.toContain("8:00 AM");
+  });
+
   it("renders newly available slots immediately when the stored selection is stale", () => {
     const courts: Court[] = [
       {

--- a/src/components/SlotGrid.tsx
+++ b/src/components/SlotGrid.tsx
@@ -42,8 +42,7 @@ export function SlotGrid({ courts }: SlotGridProps) {
   if (allDates.length === 0) {
     return (
       <div className="text-center py-4 text-gray-500 text-sm">
-        <p className="font-medium">No courts available this week</p>
-        <p className="text-xs mt-1">Check back tomorrow — slots open 7 days out at 8:00 AM</p>
+        <p className="font-medium">No bookable slots available this week</p>
       </div>
     );
   }


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: allDates is derived only from availableSlots, so a nonempty courts array whose courts currently have no slots enters this empty state. The UI then says there are no courts, even though courts exist. It also claims every slot opens seven days out at 8:00 AM despite the Court model carrying reservationWindowDays and releaseTime per court. This can mislead users about both facility availability and when to return to...

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Describe the state as having no bookable slots, not no courts. Omit the release-window claim or derive it from the supplied courts, handling differing policies explicitly.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #100



## What Changed

Finding: **Empty state falsely reports that courts are unavailable and hard-codes the booking schedule**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-112a222f28-6e62_c2cf8a3109`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.82s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.64s |
| `build` | PASS | 13.17s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
