### PR TITLE
fix: Screen readers could not tell which date was selected

### DIFF
--- a/src/components/SlotGrid.test.ts
+++ b/src/components/SlotGrid.test.ts
@@ -19,6 +19,7 @@ vi.mock("react", async () => {
 import { getEffectiveDate, SlotGrid } from "./SlotGrid";
 
 interface ElementProps {
+  "aria-pressed"?: boolean;
   children?: ReactNode;
   className?: string;
 }
@@ -47,6 +48,19 @@ function hasClass(node: ReactNode, className: string): boolean {
     node.props.className?.includes(className) === true ||
     hasClass(node.props.children, className)
   );
+}
+
+function getDateButtonPressedStates(node: ReactNode): Array<boolean | undefined> {
+  if (Array.isArray(node)) {
+    return node.flatMap(getDateButtonPressedStates);
+  }
+  if (!isValidElement<ElementProps>(node)) {
+    return [];
+  }
+  if (node.type === "button") {
+    return [node.props["aria-pressed"]];
+  }
+  return getDateButtonPressedStates(node.props.children);
 }
 
 describe("getEffectiveDate", () => {
@@ -91,5 +105,44 @@ describe("SlotGrid", () => {
     expect(hasClass(rendered, "bg-blue-600 text-white")).toBe(true);
     expect(text).toContain("09:00");
     expect(text).not.toContain("No slots");
+  });
+
+  it("exposes which date controls the displayed slots", () => {
+    const courts: Court[] = [
+      {
+        id: "court-1",
+        courtNumber: "1",
+        sportId: "tennis",
+        priceCentsPerHour: 0,
+        allowedDurations: [60],
+        reservationWindowDays: 7,
+        releaseTime: "08:00:00",
+        availableSlots: [
+          {
+            datetime: "2026-09-08 09:00:00",
+            date: "2026-09-08",
+            time: "09:00",
+          },
+          {
+            datetime: "2026-09-09 10:00:00",
+            date: "2026-09-09",
+            time: "10:00",
+          },
+        ],
+        bookingUrl: "https://example.com/book",
+      },
+    ];
+
+    storedSelection.value = "2026-09-08";
+    expect(getDateButtonPressedStates(SlotGrid({ courts }))).toEqual([
+      true,
+      false,
+    ]);
+
+    storedSelection.value = "2026-09-09";
+    expect(getDateButtonPressedStates(SlotGrid({ courts }))).toEqual([
+      false,
+      true,
+    ]);
   });
 });

--- a/src/components/SlotGrid.tsx
+++ b/src/components/SlotGrid.tsx
@@ -65,6 +65,7 @@ export function SlotGrid({ courts }: SlotGridProps) {
             <button
               key={date}
               onClick={() => setSelectedDate(date)}
+              aria-pressed={isSelected}
               className={`
                 flex-shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors
                 ${isSelected


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The active date is represented solely by CSS classes. The date buttons expose neither aria-pressed nor tab/aria-selected semantics, so assistive-technology users cannot determine which date controls the displayed slots.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Use aria-pressed={isSelected} on the buttons, or implement a complete tablist/tab pattern with aria-selected and an associated tabpanel.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #99



## What Changed

Finding: **The selected date is conveyed only visually**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-112a222f28-2d9b_3622ab3a0c`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.43s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.91s |
| `build` | PASS | 12.08s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
