### PR TITLE
fix: Screen reader users missed court availability errors

### DIFF
--- a/src/components/ErrorBanner.test.tsx
+++ b/src/components/ErrorBanner.test.tsx
@@ -1,0 +1,44 @@
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ErrorBanner } from "./ErrorBanner";
+
+interface ElementProps {
+  children?: ReactNode;
+  onClick?: () => void;
+}
+
+function findElement(
+  node: ReactNode,
+  predicate: (element: ReactElement<ElementProps>) => boolean,
+): ReactElement<ElementProps> | undefined {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findElement(child, predicate);
+      if (match) return match;
+    }
+    return undefined;
+  }
+
+  if (!isValidElement<ElementProps>(node)) return undefined;
+  if (predicate(node)) return node;
+  return findElement(node.props.children, predicate);
+}
+
+describe("ErrorBanner", () => {
+  it("announces the error and keeps retry available", () => {
+    const onRetry = vi.fn();
+    const banner = ErrorBanner({ message: "Service unavailable", onRetry });
+    const markup = renderToStaticMarkup(banner);
+
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("Service unavailable");
+    expect(markup).toMatch(/<span[^>]*aria-hidden="true"[^>]*>⚠<\/span>/);
+
+    const retryButton = findElement(banner, (element) => element.type === "button");
+    expect(retryButton).toBeDefined();
+    retryButton?.props.onClick?.();
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -8,9 +8,14 @@ interface ErrorBannerProps {
 export function ErrorBanner({ message, onRetry }: ErrorBannerProps) {
   return (
     <div className="absolute top-12 left-0 right-0 z-30 mx-4 mt-2">
-      <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 flex items-center justify-between shadow-sm">
+      <div
+        role="alert"
+        className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 flex items-center justify-between shadow-sm"
+      >
         <div className="flex items-center gap-2">
-          <span className="text-red-500 text-lg">⚠</span>
+          <span aria-hidden="true" className="text-red-500 text-lg">
+            ⚠
+          </span>
           <div>
             <p className="text-sm font-medium text-red-800">
               Failed to load availability


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The banner visually presents an error but provides no live-region semantics such as role="alert" or aria-live. If it appears after an availability request fails, screen-reader users may receive no notification that the page state changed or that retry is available.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Give the error container role="alert" (or use an appropriately configured aria-live region) and ensure the warning glyph is hidden from assistive technology if it is decorative.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #98



## What Changed

Finding: **Dynamically rendered error is not announced to assistive technology**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-0188085cde-3198_7433092824`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.27s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 3.02s |
| `build` | PASS | 12.63s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
