### PR TITLE
fix: The site’s AI training opt-out was not reaching every crawler

### DIFF
--- a/src/app/robots.txt/route.test.ts
+++ b/src/app/robots.txt/route.test.ts
@@ -12,15 +12,21 @@ describe("GET /robots.txt", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=3600, s-maxage=86400",
     );
-    for (const directive of [
-      "User-agent: *\nAllow: /",
-      "User-agent: GPTBot\nAllow: /",
-      "User-agent: ClaudeBot\nAllow: /",
-      "User-agent: PerplexityBot\nAllow: /",
-      "User-agent: Google-Extended\nAllow: /",
-      "Content-Signal: ai-train=no, search=yes, ai-input=yes",
+    const groups = body.split(/\n\s*\n/);
+    for (const userAgent of [
+      "*",
+      "GPTBot",
+      "ClaudeBot",
+      "PerplexityBot",
+      "Google-Extended",
     ]) {
-      expect(body).toContain(directive);
+      expect(groups).toContain(
+        [
+          `User-agent: ${userAgent}`,
+          "Allow: /",
+          "Content-Signal: ai-train=no, search=yes, ai-input=yes",
+        ].join("\n"),
+      );
     }
     expect(body).toContain(
       "Sitemap: https://tennis.marvinaziz.de/sitemap.xml",

--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -4,19 +4,22 @@ export const dynamic = "force-static";
 
 const ROBOTS = `User-agent: *
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 
 User-agent: GPTBot
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 
 User-agent: ClaudeBot
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 
 User-agent: PerplexityBot
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 
 User-agent: Google-Extended
 Allow: /
-
 Content-Signal: ai-train=no, search=yes, ai-input=yes
 
 Sitemap: ${SITE_URL}/sitemap.xml


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: robots.txt directives are evaluated within user-agent groups, and a crawler matching a specific group does not inherit directives from the wildcard or another crawler's group. The Content-Signal directive appears after the Google-Extended group, so group-aware processors associate it only with that group—or may ignore it as an ungrouped extension—while GPTBot, ClaudeBot, and PerplexityBot receive only Allow: /...

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Place Content-Signal in every explicitly declared crawler group, or remove the redundant specific groups and keep one wildcard group containing both Allow and Content-Signal. Add a direct route test that verifies the effective policy for every listed user agent.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #96



## What Changed

Finding: **The training opt-out is not attached to most crawler groups**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-route-b4b4e351fb-9383c1_a3bff9f5c5`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.51s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.94s |
| `build` | PASS | 12.94s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
