### PR TITLE
fix: City center appeared as the user's home before location was found

### DIFF
--- a/src/components/MapView.test.tsx
+++ b/src/components/MapView.test.tsx
@@ -1,0 +1,49 @@
+import type { PropsWithChildren } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { UserLocation } from "@/hooks/useUserLocation";
+
+vi.mock("react-map-gl/mapbox", () => ({
+  default: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  Marker: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  NavigationControl: () => null,
+}));
+
+import { MapView } from "./MapView";
+
+function renderMap(userLocation: UserLocation) {
+  return renderToStaticMarkup(
+    <MapView
+      courts={[]}
+      selectedId={null}
+      onSelectCourt={() => {}}
+      travelTimes={new Map()}
+      mapboxToken="test-token"
+      userLocation={userLocation}
+      city="sf"
+    />,
+  );
+}
+
+describe("MapView user location marker", () => {
+  it("does not label fallback city coordinates as home", () => {
+    const markup = renderMap({
+      lat: 37.7749,
+      lng: -122.4194,
+      isDefault: true,
+    });
+
+    expect(markup).not.toContain('aria-label="Home"');
+  });
+
+  it("labels a resolved user location as home", () => {
+    const markup = renderMap({
+      lat: 37.78,
+      lng: -122.42,
+      isDefault: false,
+    });
+
+    expect(markup).toContain('aria-label="Home"');
+  });
+});

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -85,9 +85,11 @@ export function MapView({
       <NavigationControl position="top-right" />
 
       {/* User location marker */}
-      <Marker latitude={userLocation.lat} longitude={userLocation.lng} anchor="center">
-        <HomePin />
-      </Marker>
+      {!userLocation.isDefault && (
+        <Marker latitude={userLocation.lat} longitude={userLocation.lng} anchor="center">
+          <HomePin />
+        </Marker>
+      )}
 
       {/* Court markers — each memoized, only re-render on its own prop changes */}
       {courts.map((loc) => (


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: MapView distinguishes default coordinates from a resolved user position when choosing its initial center, but it unconditionally renders the same coordinates as a Home marker. When geolocation is unavailable, denied, or not yet resolved, a generic city fallback is therefore labeled as the user's home, conveying false location information.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Render HomePin only when userLocation.isDefault is false, or use a visibly and accessibly distinct city-center marker for fallback coordinates.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #129



## What Changed

Finding: **Fallback coordinates are presented as the user's home**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-d32baa5a73-545c_5cfd9ee796`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.8s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.83s |
| `build` | PASS | 12.82s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
