### PR TITLE
fix: Screen reader users were not told when court data was loading

### DIFF
--- a/src/components/LoadingSkeleton.test.tsx
+++ b/src/components/LoadingSkeleton.test.tsx
@@ -1,0 +1,14 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { LoadingSkeleton } from "./LoadingSkeleton";
+
+describe("LoadingSkeleton", () => {
+  it("announces the loading state and hides the decorative spinner", () => {
+    const markup = renderToStaticMarkup(<LoadingSkeleton />);
+
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain("Loading courts...");
+    expect(markup).toMatch(/<div[^>]*aria-hidden="true"[^>]*><\/div>/);
+  });
+});

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -3,8 +3,11 @@
 export function LoadingSkeleton() {
   return (
     <div className="absolute inset-0 flex items-center justify-center bg-gray-50">
-      <div className="text-center">
-        <div className="animate-spin w-8 h-8 border-3 border-blue-600 border-t-transparent rounded-full mx-auto mb-4" />
+      <div role="status" className="text-center">
+        <div
+          aria-hidden="true"
+          className="animate-spin w-8 h-8 border-3 border-blue-600 border-t-transparent rounded-full mx-auto mb-4"
+        />
         <p className="text-gray-600 font-medium">Loading courts...</p>
         <p className="text-gray-400 text-sm mt-1">
           Fetching availability from rec.us


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The loading overlay displays a changing status message visually but provides no `role="status"`, live-region attribute, or equivalent semantic state. When this component appears after initial render, screen-reader users may receive no notification that court data is loading, making the UI appear unresponsive.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Mark the textual loading container as `role="status"` (implicitly polite) or use an appropriate `aria-live` region, and mark the spinner as decorative with `aria-hidden="true"`.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #127



## What Changed

Finding: **Loading state is not announced to assistive technologies**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-cc0246461d-f428_f44322cab4`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.71s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.67s |
| `build` | PASS | 12.51s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
