### PR TITLE
fix: Keyboard focus escaped the image preview and got lost on the page

### DIFF
--- a/src/components/DocsImagePreview.test.tsx
+++ b/src/components/DocsImagePreview.test.tsx
@@ -6,6 +6,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { DocsImagePreview, type DocsPreviewImage } from "./DocsImagePreview";
 
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
 const images: DocsPreviewImage[] = [
   {
     src: "/first.webp",
@@ -28,6 +31,20 @@ describe("DocsImagePreview", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
     document.body.style.overflow = "auto";
+    Object.defineProperties(HTMLDialogElement.prototype, {
+      showModal: {
+        configurable: true,
+        value() {
+          this.setAttribute("open", "");
+        },
+      },
+      close: {
+        configurable: true,
+        value() {
+          this.removeAttribute("open");
+        },
+      },
+    });
     container = document.createElement("div");
     document.body.append(container);
     root = createRoot(container);

--- a/src/components/DocsImagePreview.test.tsx
+++ b/src/components/DocsImagePreview.test.tsx
@@ -71,12 +71,12 @@ describe("DocsImagePreview", () => {
     render(images);
     open("Second image");
 
-    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(container.querySelector("dialog")).not.toBeNull();
     expect(document.body.style.overflow).toBe("hidden");
 
     render(images.slice(0, 1));
 
-    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(container.querySelector("dialog")).toBeNull();
     expect(document.body.style.overflow).toBe("auto");
   });
 
@@ -90,7 +90,7 @@ describe("DocsImagePreview", () => {
       window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
     });
 
-    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(container.querySelector("dialog")).toBeNull();
     expect(document.body.style.overflow).toBe("auto");
   });
 });

--- a/src/components/DocsImagePreview.tsx
+++ b/src/components/DocsImagePreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export type DocsPreviewImage = {
   src: string;
@@ -11,16 +11,42 @@ export type DocsPreviewImage = {
 
 export function DocsImagePreview({ images }: { images: DocsPreviewImage[] }) {
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const activeImage = activeIndex === null ? null : images[activeIndex];
+  const isOpen = activeIndex !== null;
+
+  function handleDialogKeydown(event: React.KeyboardEvent<HTMLDialogElement>) {
+    if (event.key !== "Tab") return;
+
+    const controls = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>(
+        "button:not(:disabled)",
+      ),
+    );
+    const firstControl = controls[0];
+    const lastControl = controls.at(-1);
+
+    if (event.shiftKey && document.activeElement === firstControl) {
+      event.preventDefault();
+      lastControl?.focus();
+    } else if (!event.shiftKey && document.activeElement === lastControl) {
+      event.preventDefault();
+      firstControl?.focus();
+    }
+  }
 
   useEffect(() => {
-    if (activeIndex === null) return;
+    if (!isOpen) return;
 
+    const dialog = dialogRef.current;
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
+    dialog?.showModal();
+    closeButtonRef.current?.focus();
 
     function handleKeydown(event: KeyboardEvent) {
-      if (event.key === "Escape") setActiveIndex(null);
       if (event.key === "ArrowRight") {
         setActiveIndex((index) =>
           index === null ? index : (index + 1) % images.length
@@ -37,8 +63,10 @@ export function DocsImagePreview({ images }: { images: DocsPreviewImage[] }) {
     return () => {
       document.body.style.overflow = previousOverflow;
       window.removeEventListener("keydown", handleKeydown);
+      if (dialog?.open) dialog.close();
+      triggerRef.current?.focus();
     };
-  }, [activeIndex, images.length]);
+  }, [isOpen, images.length]);
 
   return (
     <>
@@ -47,7 +75,10 @@ export function DocsImagePreview({ images }: { images: DocsPreviewImage[] }) {
           <button
             key={image.src}
             type="button"
-            onClick={() => setActiveIndex(index)}
+            onClick={(event) => {
+              triggerRef.current = event.currentTarget;
+              setActiveIndex(index);
+            }}
             className="group block overflow-hidden rounded-lg border border-slate-200 bg-white text-left shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
             aria-label={`${image.caption}. ${image.description} Open larger preview`}
           >
@@ -73,12 +104,16 @@ export function DocsImagePreview({ images }: { images: DocsPreviewImage[] }) {
       </div>
 
       {activeImage && activeIndex !== null && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/75 p-3 backdrop-blur-sm sm:p-6"
-          role="dialog"
-          aria-modal="true"
+        <dialog
+          ref={dialogRef}
+          className="fixed inset-0 z-50 m-0 h-full max-h-none w-full max-w-none items-center justify-center border-0 bg-transparent p-3 backdrop:bg-slate-950/75 backdrop:backdrop-blur-sm open:flex sm:p-6"
           aria-label={`${activeImage.caption} preview`}
           onClick={() => setActiveIndex(null)}
+          onKeyDown={handleDialogKeydown}
+          onCancel={(event) => {
+            event.preventDefault();
+            setActiveIndex(null);
+          }}
         >
           <div
             className="max-h-full w-full max-w-6xl overflow-hidden rounded-lg bg-white shadow-2xl dark:bg-slate-950"
@@ -94,6 +129,7 @@ export function DocsImagePreview({ images }: { images: DocsPreviewImage[] }) {
                 </p>
               </div>
               <button
+                ref={closeButtonRef}
                 type="button"
                 onClick={() => setActiveIndex(null)}
                 className="rounded-md px-2 py-1 text-sm font-medium text-slate-500 transition hover:bg-slate-100 hover:text-slate-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 dark:text-slate-400 dark:hover:bg-slate-900 dark:hover:text-white"
@@ -132,7 +168,7 @@ export function DocsImagePreview({ images }: { images: DocsPreviewImage[] }) {
               </button>
             </div>
           </div>
-        </div>
+        </dialog>
       )}
     </>
   );

--- a/tests/docs.e2e.ts
+++ b/tests/docs.e2e.ts
@@ -31,14 +31,36 @@ test("keeps documentation navigation and interactions usable", async ({ page }) 
   ).toBeVisible();
   await expect(page.locator("main").locator("..")).toHaveClass(/\bdark\b/);
 
-  await page
-    .getByRole("button", { name: /Find playable courts.*Open larger preview/ })
-    .click();
-  await expect(page.getByRole("dialog", { name: "Find playable courts preview" })).toBeVisible();
+  const previewTrigger = page.getByRole("button", {
+    name: /Find playable courts.*Open larger preview/,
+  });
+  await previewTrigger.focus();
+  await page.keyboard.press("Enter");
+
+  const dialog = page.getByRole("dialog", {
+    name: "Find playable courts preview",
+  });
+  const closeButton = dialog.getByRole("button", { name: "Close" });
+  const previousButton = dialog.getByRole("button", { name: "Previous" });
+  const nextButton = dialog.getByRole("button", { name: "Next" });
+
+  await expect(dialog).toBeVisible();
+  await expect(closeButton).toBeFocused();
   await expect(page.locator("body")).toHaveCSS("overflow", "hidden");
-  await page.getByRole("button", { name: "Close" }).click();
+
+  await page.keyboard.press("Tab");
+  await expect(previousButton).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(nextButton).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(closeButton).toBeFocused();
+  await page.keyboard.press("Shift+Tab");
+  await expect(nextButton).toBeFocused();
+
+  await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog")).toHaveCount(0);
   await expect(page.locator("body")).not.toHaveCSS("overflow", "hidden");
+  await expect(previewTrigger).toBeFocused();
 
   const dimensions = await page.evaluate(() => ({
     clientWidth: document.documentElement.clientWidth,


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: Opening the element marked aria-modal leaves focus on the thumbnail behind the overlay. There is no focus trap or inert treatment for background controls, so Tab continues through interactive content outside the dialog rather than reaching and remaining among Close, Previous, and Next. This makes the declared modal behavior inaccurate and impairs keyboard and assistive-technology users.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Save the triggering element, focus an element inside the dialog on open, trap Tab and Shift+Tab within the modal, make background content inert while open, and restore focus to the trigger on close. A well-tested accessible dialog primitive can provide these behaviors.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #124



## What Changed

Finding: **The modal does not move or contain keyboard focus**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-bb20121f8e-027f_7a6de5fbc3`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.9s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 5.05s |
| `build` | PASS | 12.5s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
