### PR TITLE
fix: Screen reader users could not distinguish availability filters

### DIFF
--- a/src/components/FilterBar.test.tsx
+++ b/src/components/FilterBar.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { FilterBar } from "./FilterBar";
+
+describe("FilterBar", () => {
+  it("gives each filter control a distinct accessible name", () => {
+    const markup = renderToStaticMarkup(
+      <FilterBar
+        filter={{ date: null, timeFrom: null, timeTo: null }}
+        onChange={() => {}}
+        availableDates={[]}
+      />,
+    );
+
+    expect(markup).toContain(
+      '<label class="sr-only" for="availability-filter-day">Day</label>',
+    );
+    expect(markup).toContain('<select id="availability-filter-day"');
+    expect(markup).toContain(
+      '<label class="sr-only" for="availability-filter-start-time">Start time</label>',
+    );
+    expect(markup).toContain('<select id="availability-filter-start-time"');
+    expect(markup).toContain(
+      '<label class="sr-only" for="availability-filter-end-time">End time</label>',
+    );
+    expect(markup).toContain('<select id="availability-filter-end-time"');
+  });
+});

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -20,7 +20,11 @@ export function FilterBar({ filter, onChange, availableDates }: FilterBarProps) 
   return (
     <div className="flex items-center gap-2 flex-wrap">
       {/* Day filter */}
+      <label className="sr-only" htmlFor="availability-filter-day">
+        Day
+      </label>
       <select
+        id="availability-filter-day"
         value={filter.date ?? ""}
         onChange={(e) =>
           onChange({ ...filter, date: e.target.value || null })
@@ -36,7 +40,11 @@ export function FilterBar({ filter, onChange, availableDates }: FilterBarProps) 
       </select>
 
       {/* Time from */}
+      <label className="sr-only" htmlFor="availability-filter-start-time">
+        Start time
+      </label>
       <select
+        id="availability-filter-start-time"
         value={filter.timeFrom ?? ""}
         onChange={(e) =>
           onChange({ ...filter, timeFrom: e.target.value || null })
@@ -54,7 +62,11 @@ export function FilterBar({ filter, onChange, availableDates }: FilterBarProps) 
       <span className="text-xs text-gray-400">–</span>
 
       {/* Time to */}
+      <label className="sr-only" htmlFor="availability-filter-end-time">
+        End time
+      </label>
       <select
+        id="availability-filter-end-time"
         value={filter.timeTo ?? ""}
         onChange={(e) =>
           onChange({ ...filter, timeTo: e.target.value || null })


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: All three select elements lack associated label elements and aria-label or aria-labelledby attributes. Their first options describe default values but do not reliably provide accessible names, so assistive technology may announce three unnamed combo boxes without distinguishing date, start time, and end time.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Associate each select with a visible or screen-reader-only label, for example "Day", "Start time", and "End time". Prefer label elements with htmlFor/id pairs.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #117



## What Changed

Finding: **Filter controls have no accessible names**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-62b1994d90-175b_5ee51bf8f1`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 15.77s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.7s |
| `build` | PASS | 12.34s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
