### PR TITLE
fix: Screen readers could not identify court filters, selections, or availability

### DIFF
--- a/src/components/LocationList.test.tsx
+++ b/src/components/LocationList.test.tsx
@@ -1,0 +1,125 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CourtLocation, TravelTime } from "@/types";
+
+const state = vi.hoisted(() => ({ search: "" }));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    ...actual,
+    useMemo: (factory: () => unknown) => factory(),
+    useState: (initial: unknown) => [initial === "" ? state.search : initial, vi.fn()],
+  };
+});
+
+import { LocationList } from "./LocationList";
+
+const courts: CourtLocation[] = [
+  {
+    id: "available-court",
+    name: "Available Court",
+    lat: 37.77,
+    lng: -122.42,
+    address: "1 Tennis Way",
+    hoursOfOperation: "",
+    accessInfo: "",
+    gettingThereInfo: "",
+    imageUrl: null,
+    courts: [],
+    availabilityStatus: "available",
+    totalSlotsToday: 2,
+    totalSlotsWeek: 2,
+  },
+  {
+    id: "later-court",
+    name: "Later Court",
+    lat: 37.78,
+    lng: -122.43,
+    address: "2 Tennis Way",
+    hoursOfOperation: "",
+    accessInfo: "",
+    gettingThereInfo: "",
+    imageUrl: null,
+    courts: [],
+    availabilityStatus: "later",
+    totalSlotsToday: 0,
+    totalSlotsWeek: 3,
+  },
+  {
+    id: "full-court",
+    name: "Full Court",
+    lat: 37.79,
+    lng: -122.44,
+    address: "3 Tennis Way",
+    hoursOfOperation: "",
+    accessInfo: "",
+    gettingThereInfo: "",
+    imageUrl: null,
+    courts: [],
+    availabilityStatus: "full",
+    totalSlotsToday: 0,
+    totalSlotsWeek: 0,
+  },
+];
+
+function renderList(selectedId: string | null = "later-court") {
+  return renderToStaticMarkup(
+    <LocationList
+      courts={courts}
+      travelTimes={new Map<string, TravelTime>()}
+      onSelectCourt={() => {}}
+      selectedId={selectedId}
+    />,
+  );
+}
+
+function getButtonAttributes(markup: string, label: string) {
+  for (const match of markup.matchAll(/<button\b([^>]*)>([\s\S]*?)<\/button>/g)) {
+    if (match[2].includes(label)) return match[1];
+  }
+
+  throw new Error(`Could not find button containing ${label}`);
+}
+
+describe("LocationList accessibility", () => {
+  it("names the search and clear controls", () => {
+    state.search = "Court";
+
+    const markup = renderList();
+
+    expect(markup).toContain('aria-label="Filter courts"');
+    expect(markup).toContain('aria-label="Clear search"');
+  });
+
+  it("exposes the active sort and selected court states", () => {
+    state.search = "";
+
+    const markup = renderList();
+
+    expect(getButtonAttributes(markup, "Distance")).toContain(
+      'aria-pressed="true"',
+    );
+    expect(getButtonAttributes(markup, "A–Z Name")).toContain(
+      'aria-pressed="false"',
+    );
+    expect(getButtonAttributes(markup, "Later Court")).toContain(
+      'aria-pressed="true"',
+    );
+    expect(getButtonAttributes(markup, "Available Court")).toContain(
+      'aria-pressed="false"',
+    );
+  });
+
+  it("provides text for every availability status", () => {
+    state.search = "";
+
+    const markup = renderList();
+
+    expect(markup).toContain("Available today");
+    expect(markup).toContain("Available later this week");
+    expect(markup).toContain("No availability this week");
+  });
+});

--- a/src/components/LocationList.tsx
+++ b/src/components/LocationList.tsx
@@ -5,6 +5,12 @@ import type { CourtLocation, TravelTime } from "@/types";
 
 type SortMode = "distance" | "name";
 
+const AVAILABILITY_LABELS: Record<CourtLocation["availabilityStatus"], string> = {
+  available: "Available today",
+  later: "Available later this week",
+  full: "No availability this week",
+};
+
 interface LocationListProps {
   courts: CourtLocation[];
   travelTimes: Map<string, TravelTime>;
@@ -46,11 +52,15 @@ export function LocationList({
       {/* Search + Sort controls */}
       <div className="px-4 py-3 bg-white border-b space-y-2">
         <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">
+          <span
+            aria-hidden="true"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm"
+          >
             🔍
           </span>
           <input
             type="text"
+            aria-label="Filter courts"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Filter courts..."
@@ -58,10 +68,12 @@ export function LocationList({
           />
           {search && (
             <button
+              type="button"
+              aria-label="Clear search"
               onClick={() => setSearch("")}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 text-xs"
             >
-              ✕
+              <span aria-hidden="true">✕</span>
             </button>
           )}
         </div>
@@ -75,7 +87,7 @@ export function LocationList({
             active={sort === "distance"}
             onClick={() => setSort("distance")}
           >
-            📍 Distance
+            <span aria-hidden="true">📍</span> Distance
           </SortButton>
           <SortButton
             active={sort === "name"}
@@ -106,6 +118,8 @@ export function LocationList({
               return (
                 <button
                   key={court.id}
+                  type="button"
+                  aria-pressed={isSelected}
                   onClick={() => onSelectCourt(court.id)}
                   className={`w-full text-left px-4 py-3 transition-colors ${
                     isSelected
@@ -123,7 +137,11 @@ export function LocationList({
                           ? "bg-yellow-500"
                           : "bg-red-500"
                       }`}
-                    />
+                    >
+                      <span className="sr-only">
+                        {AVAILABILITY_LABELS[court.availabilityStatus]}
+                      </span>
+                    </span>
 
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
@@ -139,12 +157,12 @@ export function LocationList({
                       <div className="flex items-center gap-3 mt-1.5 text-xs text-gray-500">
                         {walkMin != null && (
                           <span className="flex items-center gap-1 px-1.5 py-0.5 bg-blue-50 text-blue-700 rounded">
-                            🚶 {walkMin} min
+                            <span aria-hidden="true">🚶</span> {walkMin} min
                           </span>
                         )}
                         {driveMin != null && (
                           <span className="flex items-center gap-1 px-1.5 py-0.5 bg-purple-50 text-purple-700 rounded">
-                            🚗 {driveMin} min
+                            <span aria-hidden="true">🚗</span> {driveMin} min
                           </span>
                         )}
                         <span
@@ -185,6 +203,8 @@ function SortButton({
 }) {
   return (
     <button
+      type="button"
+      aria-pressed={active}
       onClick={onClick}
       className={`px-2 py-1 text-xs rounded-md transition-colors ${
         active


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The search field has no persistent programmatic label, the clear control is named only by a glyph, active sort state exists only in CSS, selected-court state exists only in CSS, and availability is conveyed only by dot color. Screen-reader users consequently cannot reliably identify the search and clear controls or determine the current sort, selected court, and availability status.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Add an associated or aria label to the search field, `aria-label="Clear search"` to the clear button, `aria-pressed` to sort controls, an appropriate selected-state attribute to court rows, and visually hidden availability text or an accessible label. Mark decorative emoji and glyphs aria-hidden where appropriate.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #115



## What Changed

Finding: **Visual-only state and icon controls are not exposed accessibly**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-5f55d958de-ebda_e451d37216`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.62s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.9s |
| `build` | PASS | 12.81s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
