### PR TITLE
fix: Screen readers could announce an outdated court name

### DIFF
--- a/src/components/CourtPin.tsx
+++ b/src/components/CourtPin.tsx
@@ -61,6 +61,7 @@ function CourtPinInner({
 export const CourtPin = memo(CourtPinInner, (prev, next) => {
   return (
     prev.location.id === next.location.id &&
+    prev.location.name === next.location.name &&
     prev.location.availabilityStatus === next.location.availabilityStatus &&
     prev.isSelected === next.isSelected &&
     prev.onClick === next.onClick

--- a/src/components/MapView.test.tsx
+++ b/src/components/MapView.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UserLocation } from "@/hooks/useUserLocation";
 import { CITIES } from "@/lib/constants";
+import type { CourtLocation } from "@/types";
 import { MapView } from "./MapView";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
@@ -32,6 +33,7 @@ vi.mock("react-map-gl/mapbox", () => ({
 describe("MapView location behavior", () => {
   let container: HTMLDivElement;
   let root: Root;
+  const onSelectCourt = vi.fn();
 
   beforeEach(() => {
     container = document.createElement("div");
@@ -44,13 +46,16 @@ describe("MapView location behavior", () => {
     container.remove();
   });
 
-  async function renderWithLocation(userLocation: UserLocation) {
+  async function renderWithLocation(
+    userLocation: UserLocation,
+    courts: CourtLocation[] = [],
+  ) {
     await act(async () => {
       root.render(
         <MapView
-          courts={[]}
+          courts={courts}
           selectedId={null}
-          onSelectCourt={() => {}}
+          onSelectCourt={onSelectCourt}
           travelTimes={new Map()}
           mapboxToken="test-token"
           userLocation={userLocation}
@@ -97,5 +102,42 @@ describe("MapView location behavior", () => {
       isDefault: true,
     });
     expect(container.querySelector('[aria-label="Home"]')).toBeNull();
+  });
+
+  it("updates a court marker's accessible name when its name changes", async () => {
+    const court: CourtLocation = {
+      id: "court-1",
+      name: "Old court name",
+      lat: 37.78,
+      lng: -122.42,
+      address: "",
+      hoursOfOperation: "",
+      accessInfo: "",
+      gettingThereInfo: "",
+      imageUrl: null,
+      courts: [],
+      availabilityStatus: "available",
+      totalSlotsToday: 1,
+      totalSlotsWeek: 1,
+    };
+    const defaultLocation = {
+      lat: CITIES.sf.lat,
+      lng: CITIES.sf.lng,
+      isDefault: true,
+    };
+
+    await renderWithLocation(defaultLocation, [court]);
+    expect(
+      container.querySelector('[aria-label="Old court name: Available today"]'),
+    ).not.toBeNull();
+
+    await renderWithLocation(defaultLocation, [
+      { ...court, name: "Updated court name" },
+    ]);
+    expect(
+      container.querySelector(
+        '[aria-label="Updated court name: Available today"]',
+      ),
+    ).not.toBeNull();
   });
 });

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -163,6 +163,7 @@ const CourtMarker = memo(
   (prev, next) => {
     return (
       prev.location.id === next.location.id &&
+      prev.location.name === next.location.name &&
       prev.location.availabilityStatus === next.location.availabilityStatus &&
       prev.location.lat === next.location.lat &&
       prev.location.lng === next.location.lng &&


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: CourtPin derives its aria-label from location.name, but both the CourtMarker and CourtPin custom comparators omit that field. If refreshed court data changes a name while the ID, status, coordinates, selection, and travel duration remain unchanged, React treats the props as equal and retains the old accessible label.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Include location.name in both relevant comparators, or remove the custom comparators and rely on stable immutable props plus ordinary memoization.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #128



## What Changed

Finding: **Marker memoization can leave the court's accessible name stale**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-d32baa5a73-2810_d7287821a2`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.31s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.75s |
| `build` | PASS | 12.55s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
