### PR TITLE
fix: Pages meant to stay blank after an error showed an error message

### DIFF
--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function ThrowingChild(): never {
+  throw new Error("render failed");
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ErrorBoundary", () => {
+  it.each([
+    ["null", null, ""],
+    ["zero", 0, "0"],
+  ])("honors a supplied %s fallback", (_label, fallback, expectedText) => {
+    const { container } = render(
+      <ErrorBoundary fallback={fallback}>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+
+    expect(container.textContent).toBe(expectedText);
+    expect(screen.queryByText("Something went wrong")).toBeNull();
+  });
+
+  it("renders the default fallback when none is supplied", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
-      if (this.props.fallback) return this.props.fallback;
+      if (this.props.fallback !== undefined) return this.props.fallback;
 
       return (
         <div className="flex items-center justify-center h-full p-8">


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The fallback prop accepts any ReactNode, including null, an empty string, or zero, but the truthiness check treats these valid supplied values as absent and renders the default error UI. Callers therefore cannot intentionally use a falsy fallback, such as fallback={null} to suppress output.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Distinguish an omitted fallback from a supplied falsy value, for example by returning fallback whenever this.props.fallback !== undefined.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #122



## What Changed

Finding: **Falsy custom fallbacks are ignored**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-abbb1c4576-3815_7ad26aa23b`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.62s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 5.13s |
| `build` | PASS | 13.28s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
