### PR TITLE
fix: Keyboard users could not dismiss the menu with Escape

### DIFF
--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -1,24 +1,33 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { UserLocationStatus } from "@/hooks/useUserLocation";
 import { TopBar } from "./TopBar";
 
+const defaultProps = {
+  loading: false,
+  hasData: true,
+  fetchedAt: null,
+  viewMode: "map" as const,
+  sport: "tennis" as const,
+  city: "san-francisco" as const,
+  courtCount: 1,
+  userLocationStatus: "idle" as const,
+  onRefresh: () => {},
+  onRequestLocation: () => {},
+  onToggleView: () => {},
+  onShowSearch: () => {},
+};
+
 function renderLocationButton(status: UserLocationStatus) {
   const markup = renderToStaticMarkup(
     <TopBar
-      loading={false}
-      hasData={true}
-      fetchedAt={null}
-      viewMode="map"
-      sport="tennis"
-      city="san-francisco"
-      courtCount={1}
+      {...defaultProps}
       userLocationStatus={status}
-      onRefresh={() => {}}
-      onRequestLocation={() => {}}
-      onToggleView={() => {}}
-      onShowSearch={() => {}}
     />,
   );
   const label =
@@ -36,6 +45,10 @@ function renderLocationButton(status: UserLocationStatus) {
     new RegExp(`<button[^>]*aria-label="${label}"[^>]*>`),
   )?.[0];
 }
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("TopBar location control", () => {
   const disabledAttribute = /\sdisabled(?:=""|(?=\s|>))/;
@@ -58,4 +71,30 @@ describe("TopBar location control", () => {
       expect(renderLocationButton(status)).not.toMatch(disabledAttribute);
     },
   );
+});
+
+describe("TopBar menu", () => {
+  it("reports its disclosure state and closes on Escape", async () => {
+    const user = userEvent.setup();
+    render(<TopBar {...defaultProps} />);
+    const menuButton = screen.getByRole("button", { name: "Menu" });
+
+    expect(menuButton.getAttribute("aria-expanded")).toBe("false");
+    const menuId = menuButton.getAttribute("aria-controls");
+    expect(menuId).toBeTruthy();
+    expect(document.getElementById(menuId!)).toBeNull();
+
+    await user.click(menuButton);
+
+    expect(menuButton.getAttribute("aria-expanded")).toBe("true");
+    const menu = document.getElementById(menuId!);
+    expect(menu).not.toBeNull();
+    within(menu!).getByRole("link", { name: "Docs" }).focus();
+
+    await user.keyboard("{Escape}");
+
+    expect(menuButton.getAttribute("aria-expanded")).toBe("false");
+    expect(document.getElementById(menuId!)).toBeNull();
+    expect(document.activeElement).toBe(menuButton);
+  });
 });

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useRef, useState, type KeyboardEvent } from "react";
 import { TimeSince } from "./TimeSince";
 import type { Sport, CityId } from "@/lib/constants";
 import { CITIES } from "@/lib/constants";
@@ -36,6 +36,8 @@ export function TopBar({
   onShowSearch,
 }: TopBarProps) {
   const [showMenu, setShowMenu] = useState(false);
+  const menuId = useId();
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
   const cityConfig = CITIES[city];
   const sportEmoji = sport === "tennis" ? "🎾" : "🏓";
   const sportLabel = sport === "tennis" ? "Tennis" : "Pickleball";
@@ -49,6 +51,15 @@ export function TopBar({
       : userLocationStatus === "unsupported"
       ? "Location unavailable"
       : "Use my location";
+
+  const handleMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Escape" || !showMenu) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    setShowMenu(false);
+    menuButtonRef.current?.focus();
+  };
 
   return (
     <div className="absolute top-0 left-0 right-0 z-10 bg-white/90 backdrop-blur-sm border-b shadow-sm">
@@ -135,10 +146,13 @@ export function TopBar({
           </button>
 
           {/* Menu button */}
-          <div className="relative">
+          <div className="relative" onKeyDown={handleMenuKeyDown}>
             <button
+              ref={menuButtonRef}
               onClick={() => setShowMenu(!showMenu)}
               aria-label="Menu"
+              aria-expanded={showMenu}
+              aria-controls={menuId}
               className="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 rounded transition-colors"
             >
               ☰
@@ -150,7 +164,10 @@ export function TopBar({
                   className="fixed inset-0 z-[55]"
                   onClick={() => setShowMenu(false)}
                 />
-                <div className="absolute right-0 top-8 z-[60] bg-white rounded-lg shadow-xl border py-1 w-48">
+                <div
+                  id={menuId}
+                  className="absolute right-0 top-8 z-[60] bg-white rounded-lg shadow-xl border py-1 w-48"
+                >
                   <MenuLink href="/docs">Docs</MenuLink>
                 </div>
               </>


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The menu button changes visible content but does not expose `aria-expanded` or associate itself with the popup, and no keyboard handler closes the popup on Escape. Assistive-technology users cannot determine whether the disclosure is open, while keyboard users lack the conventional dismissal behavior.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Add `aria-expanded`, `aria-controls`, a stable popup id, and Escape handling. Return focus to the trigger when dismissal follows focus movement into the popup.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #120



## What Changed

Finding: **Menu disclosure state and Escape dismissal are missing**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-72db41873d-4ddd_2b9f40e64c`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.6s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 4.86s |
| `build` | PASS | 12.29s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
