### PR TITLE
fix: The menu stayed open when visitors clicked elsewhere

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TimeSince } from "./TimeSince";
 import type { Sport, CityId } from "@/lib/constants";
 import { CITIES } from "@/lib/constants";
@@ -36,6 +36,7 @@ export function TopBar({
   onShowSearch,
 }: TopBarProps) {
   const [showMenu, setShowMenu] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
   const cityConfig = CITIES[city];
   const sportEmoji = sport === "tennis" ? "🎾" : "🏓";
   const sportLabel = sport === "tennis" ? "Tennis" : "Pickleball";
@@ -49,6 +50,21 @@ export function TopBar({
       : userLocationStatus === "unsupported"
       ? "Location unavailable"
       : "Use my location";
+
+  useEffect(() => {
+    if (!showMenu) return;
+
+    function handleOutsideClick(event: MouseEvent) {
+      if (menuRef.current?.contains(event.target as Node)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      setShowMenu(false);
+    }
+
+    document.addEventListener("click", handleOutsideClick, true);
+    return () => document.removeEventListener("click", handleOutsideClick, true);
+  }, [showMenu]);
 
   return (
     <div className="absolute top-0 left-0 right-0 z-10 bg-white/90 backdrop-blur-sm border-b shadow-sm">
@@ -135,7 +151,7 @@ export function TopBar({
           </button>
 
           {/* Menu button */}
-          <div className="relative">
+          <div ref={menuRef} className="relative">
             <button
               onClick={() => setShowMenu(!showMenu)}
               aria-label="Menu"
@@ -145,15 +161,9 @@ export function TopBar({
             </button>
 
             {showMenu && (
-              <>
-                <div
-                  className="fixed inset-0 z-[55]"
-                  onClick={() => setShowMenu(false)}
-                />
-                <div className="absolute right-0 top-8 z-[60] bg-white rounded-lg shadow-xl border py-1 w-48">
-                  <MenuLink href="/docs">Docs</MenuLink>
-                </div>
-              </>
+              <div className="absolute right-0 top-8 z-[60] bg-white rounded-lg shadow-xl border py-1 w-48">
+                <MenuLink href="/docs">Docs</MenuLink>
+              </div>
             )}
           </div>
         </div>

--- a/tests/top-bar.e2e.ts
+++ b/tests/top-bar.e2e.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+test("closes the menu when the page below the top bar is clicked", async ({
+  page,
+}) => {
+  await page.route("**/api/courts?**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ courts: [], fetchedAt: null }),
+    }),
+  );
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Menu" }).click();
+  const docsLink = page.getByRole("link", { name: "Docs" });
+  await expect(docsLink).toBeVisible();
+
+  await page.mouse.click(100, 500);
+
+  await expect(docsLink).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Menu" }).click();
+  await page.getByRole("link", { name: "Docs" }).click();
+  await expect(page).toHaveURL(/\/docs$/);
+});


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The top-level element applies backdrop-filter through `backdrop-blur-sm`, which establishes a containing block for fixed-position descendants. Consequently, the `fixed inset-0` dismissal layer is bounded by the top bar instead of the viewport. Clicking the page below the bar can leave the menu open and interact with underlying content.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Move the dismissal layer outside the backdrop-filter containing block, render the popover/backdrop through a portal, or use a document-level outside-pointer handler with proper cleanup.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #119



## What Changed

Finding: **Outside-click backdrop is constrained by the filtered top bar**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-72db41873d-258a_935037359d`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.48s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.82s |
| `build` | PASS | 12.91s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
