### PR TITLE
fix: Tomorrow showed as a weekday after daylight saving ended

### DIFF
--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -92,6 +92,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -209,6 +210,40 @@ describe("CommandPalette keyboard handling", () => {
     expect(callbacks.onClose).not.toHaveBeenCalled();
   });
 
+  it("labels the next Los Angeles calendar date as Tomorrow after fall-back", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-11-01T07:30:00.000Z"));
+    setDesktop(true);
+
+    const { container } = render(
+      <CommandPalette
+        courts={courts}
+        travelTimes={new Map()}
+        sport="tennis"
+        city="sf"
+        filter={{
+          date: null,
+          weekendOnly: false,
+          timeFrom: null,
+          timeTo: null,
+        }}
+        availableDates={["2026-11-02"]}
+        userLocationStatus="idle"
+        onSelectCourt={vi.fn()}
+        onSportChange={vi.fn()}
+        onCityChange={vi.fn()}
+        onFilterChange={vi.fn()}
+        onRequestLocation={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const tomorrowButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button[data-idx]"),
+    ).find((button) => button.textContent?.includes("Tomorrow"));
+    expect(tomorrowButton).toBeDefined();
+  });
+
   it("clears Weekend when a desktop date button is activated", async () => {
     setDesktop(true);
     const user = userEvent.setup();
@@ -225,7 +260,7 @@ describe("CommandPalette keyboard handling", () => {
           timeFrom: "12:00",
           timeTo: "17:00",
         }}
-        availableDates={["2026-09-14"]}
+        availableDates={["2020-09-14"]}
         userLocationStatus="idle"
         onSelectCourt={vi.fn()}
         onSportChange={vi.fn()}
@@ -243,7 +278,7 @@ describe("CommandPalette keyboard handling", () => {
     await user.click(dateButton!);
 
     expect(onFilterChange).toHaveBeenCalledWith({
-      date: "2026-09-14",
+      date: "2020-09-14",
       weekendOnly: false,
       timeFrom: "12:00",
       timeTo: "17:00",

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -953,9 +953,10 @@ function formatDateLabel(dateStr: string): string {
   });
   if (dateStr === today) return "Today";
 
-  const tomorrow = new Date(Date.now() + 86400000).toLocaleDateString("en-CA", {
-    timeZone: "America/Los_Angeles",
-  });
+  const [year, month, day] = today.split("-").map(Number);
+  const tomorrow = new Date(Date.UTC(year, month - 1, day + 1))
+    .toISOString()
+    .slice(0, 10);
   if (dateStr === tomorrow) return "Tomorrow";
 
   const date = new Date(dateStr + "T12:00:00-07:00");

--- a/src/components/FilterBar.test.tsx
+++ b/src/components/FilterBar.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FilterBar } from "./FilterBar";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("FilterBar date labels", () => {
+  it("labels the next Los Angeles calendar date as Tomorrow after fall-back", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-11-01T07:30:00.000Z"));
+
+    const markup = renderToStaticMarkup(
+      <FilterBar
+        filter={{ date: null, timeFrom: null, timeTo: null }}
+        onChange={() => {}}
+        availableDates={["2026-11-02"]}
+      />,
+    );
+
+    expect(markup).toContain(">Tomorrow</option>");
+  });
+});

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -106,9 +106,10 @@ function formatDateLabel(dateStr: string): string {
   });
   if (dateStr === today) return "Today";
 
-  const tomorrow = new Date(Date.now() + 86400000).toLocaleDateString("en-CA", {
-    timeZone: "America/Los_Angeles",
-  });
+  const [year, month, day] = today.split("-").map(Number);
+  const tomorrow = new Date(Date.UTC(year, month - 1, day + 1))
+    .toISOString()
+    .slice(0, 10);
   if (dateStr === tomorrow) return "Tomorrow";
 
   const date = new Date(dateStr + "T12:00:00-07:00");


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The function derives tomorrow by adding exactly 86,400,000 milliseconds to the current instant. A local calendar day in America/Los_Angeles lasts 25 hours when daylight-saving time ends, so shortly after midnight on that transition day the resulting instant can still format as today. The actual next date consequently receives a generic weekday label instead of "Tomorrow".

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Perform calendar-day arithmetic in America/Los_Angeles rather than elapsed-time arithmetic, such as constructing the next local calendar date with a timezone-aware utility or incrementing normalized date components.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #116



## What Changed

Finding: **Tomorrow is mislabeled around the end of daylight-saving time**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-62b1994d90-07ee_cc8a3a9706`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.71s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 3.12s |
| `build` | PASS | 13.09s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
