### PR TITLE
fix: AI assistants could see duplicate court actions after reopening the page

### DIFF
--- a/src/components/WebMcpBridge.test.tsx
+++ b/src/components/WebMcpBridge.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WebMcpBridge } from "./WebMcpBridge";
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(navigator, "modelContext");
+  vi.restoreAllMocks();
+});
+
+describe("WebMcpBridge", () => {
+  it("removes registered tools on unmount before registering them again", () => {
+    const activeTools = new Set<string>();
+    const registerTool = vi.fn((tool: { name: string }) => {
+      activeTools.add(tool.name);
+    });
+    const unregisterTool = vi.fn((name: string) => {
+      activeTools.delete(name);
+    });
+
+    Object.defineProperty(navigator, "modelContext", {
+      configurable: true,
+      value: { registerTool, unregisterTool },
+    });
+
+    const firstMount = render(<WebMcpBridge />);
+    expect(activeTools).toEqual(
+      new Set(["sf_tennis_get_courts", "sf_tennis_get_docs"]),
+    );
+
+    firstMount.unmount();
+    expect(unregisterTool).toHaveBeenCalledTimes(2);
+    expect(activeTools.size).toBe(0);
+
+    render(<WebMcpBridge />);
+    expect(registerTool).toHaveBeenCalledTimes(4);
+    expect(activeTools).toEqual(
+      new Set(["sf_tennis_get_courts", "sf_tennis_get_docs"]),
+    );
+  });
+
+  it("aborts signal-based registrations on unmount", () => {
+    const activeTools = new Set<string>();
+    const registerTool = vi.fn(
+      (tool: { name: string }, options?: { signal?: AbortSignal }) => {
+        activeTools.add(tool.name);
+        options?.signal?.addEventListener("abort", () => {
+          activeTools.delete(tool.name);
+        });
+      },
+    );
+
+    Object.defineProperty(navigator, "modelContext", {
+      configurable: true,
+      value: { registerTool },
+    });
+
+    const mounted = render(<WebMcpBridge />);
+    expect(activeTools.size).toBe(2);
+
+    mounted.unmount();
+    expect(activeTools.size).toBe(0);
+  });
+
+  it("observes registration promises before aborting them", () => {
+    const registrations = [Promise.resolve(), Promise.resolve()];
+    const catchSpies = registrations.map((registration) =>
+      vi.spyOn(registration, "catch"),
+    );
+    const registerTool = vi
+      .fn()
+      .mockReturnValueOnce(registrations[0])
+      .mockReturnValueOnce(registrations[1]);
+
+    Object.defineProperty(navigator, "modelContext", {
+      configurable: true,
+      value: { registerTool },
+    });
+
+    const mounted = render(<WebMcpBridge />);
+    mounted.unmount();
+
+    for (const catchSpy of catchSpies) {
+      expect(catchSpy).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("invokes the cleanup returned by bulk tool registration", () => {
+    const dispose = vi.fn();
+    const provideTools = vi.fn(() => dispose);
+
+    Object.defineProperty(navigator, "modelContext", {
+      configurable: true,
+      value: { provideTools },
+    });
+
+    const mounted = render(<WebMcpBridge />);
+    mounted.unmount();
+
+    expect(provideTools).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears provided context on unmount when no cleanup is returned", () => {
+    const provideContext = vi.fn();
+
+    Object.defineProperty(navigator, "modelContext", {
+      configurable: true,
+      value: { provideContext },
+    });
+
+    const mounted = render(<WebMcpBridge />);
+    mounted.unmount();
+
+    expect(provideContext).toHaveBeenCalledTimes(2);
+    expect(provideContext.mock.calls[1]?.[0]).toMatchObject({ tools: [] });
+  });
+});

--- a/src/components/WebMcpBridge.tsx
+++ b/src/components/WebMcpBridge.tsx
@@ -11,13 +11,45 @@ type WebMcpTool = {
 
 type ModelContextApi = {
   provideTools?: (tools: WebMcpTool[]) => unknown;
+  clearTools?: () => unknown;
   provideContext?: (context: {
     name: string;
     description: string;
     tools: WebMcpTool[];
   }) => unknown;
-  registerTool?: (tool: WebMcpTool) => unknown;
+  clearContext?: () => unknown;
+  registerTool?: (
+    tool: WebMcpTool,
+    options?: { signal?: AbortSignal },
+  ) => unknown;
+  unregisterTool?: (name: string) => unknown;
 };
+
+function runRegistrationCleanup(handle: unknown): boolean {
+  if (typeof handle === "function") {
+    handle();
+    return true;
+  }
+
+  if (!handle || typeof handle !== "object") return false;
+
+  const registration = handle as {
+    unregister?: unknown;
+    dispose?: unknown;
+  };
+
+  if (typeof registration.unregister === "function") {
+    registration.unregister.call(handle);
+    return true;
+  }
+
+  if (typeof registration.dispose === "function") {
+    registration.dispose.call(handle);
+    return true;
+  }
+
+  return false;
+}
 
 function asChoice(value: unknown, fallback: string, allowed: string[]): string {
   return typeof value === "string" && allowed.includes(value) ? value : fallback;
@@ -65,22 +97,64 @@ export function WebMcpBridge() {
     ];
 
     if (typeof modelContext.provideTools === "function") {
-      modelContext.provideTools(tools);
-      return;
+      const registration = modelContext.provideTools(tools);
+      return () => {
+        if (runRegistrationCleanup(registration)) return;
+        if (typeof modelContext.clearTools === "function") {
+          modelContext.clearTools();
+          return;
+        }
+        modelContext.provideTools?.([]);
+      };
     }
 
     if (typeof modelContext.provideContext === "function") {
-      modelContext.provideContext({
+      const context = {
         name: "SF Tennis",
         description:
           "Live public tennis and pickleball availability with API docs.",
         tools,
-      });
-      return;
+      };
+      const registration = modelContext.provideContext(context);
+      return () => {
+        if (runRegistrationCleanup(registration)) return;
+        if (typeof modelContext.clearContext === "function") {
+          modelContext.clearContext();
+          return;
+        }
+        modelContext.provideContext?.({ ...context, tools: [] });
+      };
     }
 
     if (typeof modelContext.registerTool === "function") {
-      tools.forEach((tool) => modelContext.registerTool?.(tool));
+      const registrations = tools.map((tool) => {
+        const controller = new AbortController();
+        const handle = modelContext.registerTool?.(tool, {
+          signal: controller.signal,
+        });
+        void Promise.resolve(handle).catch((error: unknown) => {
+          if (!controller.signal.aborted) {
+            console.warn(`Unable to register WebMCP tool "${tool.name}"`, error);
+          }
+        });
+
+        return {
+          controller,
+          handle,
+          tool,
+        };
+      });
+
+      return () => {
+        registrations.forEach(({ controller, handle, tool }) => {
+          if (runRegistrationCleanup(handle)) return;
+          if (typeof modelContext.unregisterTool === "function") {
+            modelContext.unregisterTool(tool.name);
+            return;
+          }
+          controller.abort();
+        });
+      };
     }
   }, []);
 


### PR DESCRIPTION
## PM TLDR

**What this means:** This fixes a product bug: The effect registers or provides tools but returns no cleanup function and ignores any registration handle returned by the host API. With an additive registerTool implementation, React development remounts, hot reloads, or genuine unmount/remount cycles can leave duplicate or stale registrations. A stale registration also retains the execute closures after the component is gone.

**Why it matters:** The change removes a user-visible failure mode or operational risk while keeping the fix scoped to the reported issue.

**Fix approach:** Implement the teardown contract for each supported Model Context API variant. For registerTool, expose and call the matching unregister operation for both tool names; for provideTools/provideContext, retain and invoke any documented disposer or explicitly clear the provided registration during cleanup.

**How it was checked:** `npm ci` passed; `typecheck` and `build` passed.

Closes #126



## What Changed

Finding: **WebMCP tools are registered without effect teardown**

Source: one Clawpatch finding.

This PR contains the minimal code/test change needed for finding `fnd_sig-feat-ui-flow-c935c7197c-64e0_53575ff409`.

## Risk

Low-to-medium. The PR is intentionally scoped to one automated finding and has a separate Codex review comment before it is considered ready.

## Verification

Setup commands:

| Command | Result | Duration |
|---|---:|---:|
| `npm ci` | PASS | 16.42s |

Validation commands:

| Command | Result | Duration |
|---|---:|---:|
| `typecheck` | PASS | 2.83s |
| `build` | PASS | 12.19s |

Screenshot commands:

No commands configured.

Artifacts:

-

Env var names available during validation:

-

## Not Verified

No manual product review was performed. Secrets were copied only into the temporary VPS worktree and were not committed.
